### PR TITLE
[`fix`] Various fixes for non-Posix machines

### DIFF
--- a/model2vec/distill/tokenizer.py
+++ b/model2vec/distill/tokenizer.py
@@ -22,7 +22,7 @@ def remove_tokens(tokenizer: Tokenizer, tokens_to_remove: list[str]) -> Tokenize
     """
     with NamedTemporaryFile(mode="w+") as temp_file:
         tokenizer.save(temp_file.name)
-        data = json.load(open(temp_file.name))
+        data = json.load(temp_file)
         vocab: dict[str, int] = data["model"]["vocab"]
 
         n_tokens = len(vocab)

--- a/model2vec/distill/tokenizer.py
+++ b/model2vec/distill/tokenizer.py
@@ -20,7 +20,7 @@ def remove_tokens(tokenizer: Tokenizer, tokens_to_remove: list[str]) -> Tokenize
     :param tokens_to_remove: The tokens to remove.
     :return: The modified tokenizer.
     """
-    with NamedTemporaryFile(mode="w+") as temp_file:
+    with NamedTemporaryFile(mode="w+", encoding="utf8") as temp_file:
         tokenizer.save(temp_file.name)
         data = json.load(temp_file)
         vocab: dict[str, int] = data["model"]["vocab"]

--- a/model2vec/utils.py
+++ b/model2vec/utils.py
@@ -81,10 +81,10 @@ def load_pretrained(
     else:
         logger.info("Folder does not exist locally, attempting to use huggingface hub.")
         embeddings_path = huggingface_hub.hf_hub_download(
-            str(folder_or_repo_path), "embeddings.safetensors", token=token
+            folder_or_repo_path.as_posix(), "embeddings.safetensors", token=token
         )
-        config_path = huggingface_hub.hf_hub_download(str(folder_or_repo_path), "config.json", token=token)
-        tokenizer_path = huggingface_hub.hf_hub_download(str(folder_or_repo_path), "tokenizer.json", token=token)
+        config_path = huggingface_hub.hf_hub_download(folder_or_repo_path.as_posix(), "config.json", token=token)
+        tokenizer_path = huggingface_hub.hf_hub_download(folder_or_repo_path.as_posix(), "tokenizer.json", token=token)
 
     opened_tensor_file = cast(SafeOpenProtocol, safetensors.safe_open(embeddings_path, framework="numpy"))
     embeddings = opened_tensor_file.get_tensor("embeddings")


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use `Path.as_posix()` rather than `str(Path)` to avoid `\` when `/` is expected.
* Don't reopen already opened file - this crashes on Windows due to a PermissionError
* Open file in "utf8" so they're properly readable/writable

## Details
This PR introduces a few fixes required for this project to work correctly on Windows devices. 

Note: the tests passed on Windows despite these issues, likely as everything in the test suite is mocked. 

- Tom Aarsen