### PR TITLE
[`enh`] Rely on Jinja for model card, use model id/path in snippet

### DIFF
--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -85,11 +85,12 @@ class StaticModel(nn.Module):
             )
         self.config["normalize"] = value
 
-    def save_pretrained(self, path: PathLike) -> None:
+    def save_pretrained(self, path: PathLike, model_name: str | None = None) -> None:
         """
         Save the pretrained model.
 
         :param path: The path to save to.
+        :param model_name: The model name to use in the Model Card.
         """
         save_pretrained(
             folder_path=Path(path),
@@ -98,6 +99,7 @@ class StaticModel(nn.Module):
             config=self.config,
             base_model_name=self.base_model_name,
             language=self.language,
+            model_name=model_name,
         )
 
     def forward(self, ids: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
@@ -217,5 +219,5 @@ class StaticModel(nn.Module):
         :param token: The huggingface token to use.
         """
         with TemporaryDirectory() as temp_dir:
-            self.save_pretrained(temp_dir)
+            self.save_pretrained(temp_dir, model_name=repo_id)
             push_folder_to_hub(Path(temp_dir), repo_id, token)

--- a/model2vec/model_card_template.md
+++ b/model2vec/model_card_template.md
@@ -1,13 +1,8 @@
 ---
-model_name: {model_name}
-base_model: {base_model}
-language: {language}
-library_name: 'model2vec'
-license: {license}
-tags: [embeddings, static-embeddings]
+{{ card_data }}
 ---
 
-# {model_name} Model Card
+# {{ model_name }} Model Card
 
 Model2Vec distills a Sentence Transformer into a small, static model.
 This model is ideal for applications requiring fast, lightweight embeddings.
@@ -25,7 +20,11 @@ pip install model2vec
 A StaticModel can be loaded using the `from_pretrained` method:
 ```python
 from model2vec import StaticModel
-model = StaticModel.from_pretrained("minishlab/M2V_base_output")
+
+# Load a pretrained Model2Vec model
+model = StaticModel.from_pretrained("{{ model_name }}")
+
+# Compute text embeddings
 embeddings = model.encode(["Example sentence"])
 ```
 
@@ -49,10 +48,6 @@ Model2vec creates a small, fast, and powerful model that outperforms other stati
 
 It works by passing a vocabulary through a sentence transformer model, then reducing the dimensionality of the resulting embeddings using PCA, and finally weighting the embeddings using zipf weighting. During inference, we simply take the mean of all token embeddings occurring in a sentence.
 
-## Citation
-
-Please cite the [Model2Vec repository](https://github.com/MinishLab/model2vec) if you use this model in your work.
-
 ## Additional Resources
 
 - [Model2Vec Repo](https://github.com/MinishLab/model2vec)
@@ -61,4 +56,16 @@ Please cite the [Model2Vec repository](https://github.com/MinishLab/model2vec) i
 
 ## Model Authors
 
-Model2Vec was developed by the [Minish Lab](https://github.com/MinishLab) team consisting of Stephan Tulkens and Thomas van Dongen.
+Model2Vec was developed by the [Minish Lab](https://github.com/MinishLab) team consisting of [Stephan Tulkens](https://github.com/stephantul) and [Thomas van Dongen](https://github.com/Pringled).
+
+## Citation
+
+Please cite the [Model2Vec repository](https://github.com/MinishLab/model2vec) if you use this model in your work.
+```
+@software{minishlab2024word2vec,
+  authors = {Stephan Tulkens, Thomas van Dongen},
+  title = {Model2Vec: Turn any Sentence Transformer into a Small Fast Model},
+  year = {2024},
+  url = {https://github.com/MinishLab/model2vec},
+}
+```


### PR DESCRIPTION
Hello!

## Pull Request overview
* Rely on Jinja for model card - auto-formats the card data
* Use the model ID/path in the auto-generated snippet
* Spread out the snippet a bit, with some new comments
* Move citation down to the bottom, and add the citation itself
* Add links to your GitHubs (you can also remove this if you'd rather not have it)

## Details
The `ModelCard` and `ModelCardData` has some nice extra features that prevents us from having to worry about how to format the metadata at the top of the model card. The overview should hopefully be clear enough to explain all of the changes.

## Note
* Do you still want to use `minishlab2024word2vec`? Or maybe replace that last bit with model2vec?
* The first sentence in the model card explains how Model2Vec can be used to distill, but the reader is already on such a distilled model - they're likely more interested in reading what this model does. I think it's not a big issue, but perhaps a rewrite can be better

---

- Tom Aarsen