### PR TITLE
Add median token length as limit

### DIFF
--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -56,6 +56,7 @@ class StaticModel(nn.Module):
         else:
             self.unk_token_id = None
 
+        self.median_token_length = int(np.median([len(token) for token in self.tokens]))
         self.config = config
         self.base_model_name = base_model_name
         self.language = language
@@ -123,6 +124,10 @@ class StaticModel(nn.Module):
         :param max_length: The maximum length of the sentence.
         :return: The tokens.
         """
+        if max_length is not None:
+            m = max_length * self.median_token_length
+            sentences = [sentence[:m] for sentence in sentences]
+
         encodings: list[Encoding] = self.tokenizer.encode_batch(sentences, add_special_tokens=False)
         encodings_ids = [encoding.ids for encoding in encodings]
 


### PR DESCRIPTION
This PR adds a speed optimization:

For longer texts, tokenization can take up 90-95% of our time, because we tokenize the entire text. However, we usually only take the first N (usually 512) tokens of text. So, it makes sense to only really tokenize the first X tokens of a text. We therefore truncate texts to N * median(token_lengths). A test on wikipedia shows that this doesn't lead to any unnecessary truncation, i.e., it never truncated to a length < 512 tokens.