### PR TITLE
Add support for huggingface_hub>=0.25.0

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -3,7 +3,6 @@ from typing import Literal
 
 import numpy as np
 from huggingface_hub import model_info
-from huggingface_hub.utils._errors import RepositoryNotFoundError
 from sklearn.decomposition import PCA
 from tokenizers.models import BPE, Unigram
 from transformers import AutoModel, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerFast
@@ -15,6 +14,14 @@ from model2vec.distill.inference import (
 from model2vec.distill.tokenizer import add_tokens, preprocess_vocabulary, remove_tokens
 from model2vec.distill.utils import select_optimal_device
 from model2vec.model import StaticModel
+
+try:
+    # For huggingface_hub>=0.25.0
+    from huggingface_hub.errors import RepositoryNotFoundError
+except ImportError:
+    # For huggingface_hub<0.25.0
+    from huggingface_hub.utils._errors import RepositoryNotFoundError
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -4,12 +4,18 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from huggingface_hub.utils._errors import RepositoryNotFoundError
 from pytest import LogCaptureFixture
 from transformers import AutoModel, BertTokenizerFast
 
 from model2vec.distill.distillation import _clean_vocabulary, _post_process_embeddings, distill, distill_from_model
 from model2vec.model import StaticModel
+
+try:
+    # For huggingface_hub>=0.25.0
+    from huggingface_hub.errors import RepositoryNotFoundError
+except ImportError:
+    # For huggingface_hub<0.25.0
+    from huggingface_hub.utils._errors import RepositoryNotFoundError
 
 rng = np.random.default_rng()
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add support for huggingface_hub>=0.25.0

## Details
Since huggingface_hub v0.25.0, the `huggingface_hub.utils._errors` file was removed, see https://github.com/huggingface/huggingface_hub/pull/2474. Rather than only using `from huggingface_hub.errors import RepositoryNotFoundError` and requiring at least `huggingface_hub>=0.25.0`, this fix allows for all recent versions to work.

cc @Wauplin to inform you of the breaking change as it wasn't explicitly mentioned in your release notes (although I recognize that you could argue that `_errors` was a private file that shouldn't be used outside of hf_hub itself).

- Tom Aarsen