### PR TITLE
Fix distill model bos and eos token

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -53,7 +53,7 @@ def distill_from_model(
     :param device: The device to use.
     :param pca_dims: The number of components to use for PCA.
         If this is None, we don't apply PCA.
-        If this is 'auto', we don't reduce dimenionality, but still apply PCA.
+        If this is 'auto', we don't reduce dimensionality, but still apply PCA.
     :param apply_zipf: Whether to apply Zipf weighting to the embeddings.
     :param use_subword: Whether to keep subword tokens in the vocabulary. If this is False, you must pass a vocabulary, and the returned tokenizer will only detect full words.
     :raises: ValueError if the PCA dimension is larger than the number of dimensions in the embeddings.

--- a/model2vec/distill/inference.py
+++ b/model2vec/distill/inference.py
@@ -117,10 +117,10 @@ def create_output_embeddings_from_model_name(
 
     # Work-around to get the eos and bos token ids without having to go into tokenizer internals.
     dummy_encoding = tokenizer.encode("A")
-    eos_token_id, bos_token_id = dummy_encoding[0], dummy_encoding[-1]
+    bos_token_id, eos_token_id = dummy_encoding[0], dummy_encoding[-1]
 
-    eos = torch.full([len(ids)], fill_value=eos_token_id)
     bos = torch.full([len(ids)], fill_value=bos_token_id)
+    eos = torch.full([len(ids)], fill_value=eos_token_id)
 
     stacked = torch.stack([bos, ids, eos], dim=1)
 

--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -184,7 +184,7 @@ class StaticModel(nn.Module):
 
         :param path: The path to load your static model from.
         :param token: The huggingface token to use.
-        :return: A StaticEmbedder
+        :return: A StaticModel
         """
         embeddings, tokenizer, config, metadata = load_pretrained(path, token=token)
 


### PR DESCRIPTION
The `bos_token_id` and `eos_token_id` appear to be reversed in the `create_output_embeddings_from_model_name` function within `model2vec/distill/inference.py`.

When I testing with following code
```python
from transformers import AutoModel, AutoTokenizer
from model2vec.distill import distill_from_model
model_name = "bert-base-uncased"
model = AutoModel.from_pretrained(model_name)
tokenizer = AutoTokenizer.from_pretrained(model_name)
m2v_model = distill_from_model(model=model, tokenizer=tokenizer, pca_dims=256)
```
before the fix `bos_token_id` is `102` and `eos_token_id` is `101` but for BERT tokenizer the correct `bos_token_id` and `eos_token_id` should be
```python
>>> tokenizer.cls_token_id
101
>>> tokenizer.sep_token_id
102
```