### PR TITLE
fix: move tensor to cpu

### DIFF
--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -111,7 +111,7 @@ class StaticModel(nn.Module):
         """
         save_pretrained(
             folder_path=Path(path),
-            embeddings=self.embedding.weight.numpy(),
+            embeddings=self.embedding.weight.cpu().numpy(),
             tokenizer=self.tokenizer,
             config=self.config,
             base_model_name=self.base_model_name,


### PR DESCRIPTION
We didn't move the tensor to cpu before trying to dump it, which causes an error if the model is on another device.