### PR TITLE
feat: make encode_batch_fast optional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def mock_tokenizer() -> Tokenizer:
     return tokenizer
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def mock_berttokenizer() -> AutoTokenizer:
     """Load the real BertTokenizerFast from the provided tokenizer.json file."""
     return AutoTokenizer.from_pretrained("tests/data/test_tokenizer")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -25,6 +25,17 @@ def test_initialization_token_vector_mismatch(mock_tokenizer: Tokenizer, mock_co
         StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
 
 
+def test_tokenize(mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]) -> None:
+    """Test tokenization of a sentence."""
+    model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
+    model._can_encode_fast = True
+    tokens_fast = model.tokenize(["word1 word2"])
+    model._can_encode_fast = False
+    tokens_slow = model.tokenize(["word1 word2"])
+
+    assert tokens_fast == tokens_slow
+
+
 def test_encode_single_sentence(
     mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
 ) -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -36,6 +36,16 @@ def test_tokenize(mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_conf
     assert tokens_fast == tokens_slow
 
 
+def test_encode_batch_fast(
+    mock_vectors: np.ndarray, mock_berttokenizer: Tokenizer, mock_config: dict[str, str]
+) -> None:
+    """Test tokenization of a sentence."""
+    if hasattr(mock_berttokenizer, "encode_batch_fast"):
+        del mock_berttokenizer.encode_batch_fast
+        model = StaticModel(vectors=mock_vectors, tokenizer=mock_berttokenizer, config=mock_config)
+        assert not model._can_encode_fast
+
+
 def test_encode_single_sentence(
     mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
 ) -> None:


### PR DESCRIPTION
If tokenizers < 0.20 is installed the code can still work, but we need a flag to know which function to call. I think this is worth supporting, because 0.20 is relatively new.