### PR TITLE
feat: Add multiprocessing

### DIFF
--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -18,7 +18,7 @@ PathLike = Union[Path, str]
 
 logger = getLogger(__name__)
 
-MULTIPROCESSING_THRESHOLD = 10_000  # Minimum number of sentences to use multiprocessing
+_MULTIPROCESSING_THRESHOLD = 10_000  # Minimum number of sentences to use multiprocessing
 
 
 class StaticModel:
@@ -191,6 +191,7 @@ class StaticModel:
         :param batch_size: The batch size to use.
         :param show_progress_bar: Whether to show the progress bar.
         :param use_multiprocessing: Whether to use multiprocessing.
+            By default, this is enabled for inputs > 10k sentences and disabled otherwise.
         :return: The encoded sentences with an embedding per token.
         """
         was_single = False
@@ -203,7 +204,7 @@ class StaticModel:
         total_batches = math.ceil(len(sentences) / batch_size)
 
         # Use joblib for multiprocessing if requested, and if we have enough sentences
-        if use_multiprocessing and len(sentences) > MULTIPROCESSING_THRESHOLD:
+        if use_multiprocessing and len(sentences) > _MULTIPROCESSING_THRESHOLD:
             # Disable parallelism for tokenizers
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -259,6 +260,7 @@ class StaticModel:
             If this is None, no truncation is done.
         :param batch_size: The batch size to use.
         :param use_multiprocessing: Whether to use multiprocessing.
+            By default, this is enabled for inputs > 10k sentences and disabled otherwise.
         :param **kwargs: Any additional arguments. These are ignored.
         :return: The encoded sentences. If a single sentence was passed, a vector is returned.
         """
@@ -271,8 +273,10 @@ class StaticModel:
         sentence_batches = list(self._batch(sentences, batch_size))
         total_batches = math.ceil(len(sentences) / batch_size)
 
+        ids = self.tokenize(sentences=sentences, max_length=max_length)
+
         # Use joblib for multiprocessing if requested, and if we have enough sentences
-        if use_multiprocessing and len(sentences) > MULTIPROCESSING_THRESHOLD:
+        if use_multiprocessing and len(sentences) > _MULTIPROCESSING_THRESHOLD:
             # Disable parallelism for tokenizers
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
 

--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -17,7 +17,7 @@ PathLike = Union[Path, str]
 
 logger = getLogger(__name__)
 
-MULTIPROCESSING_THRESHOLD = 10_000
+MULTIPROCESSING_THRESHOLD = 10_000  # Minimum number of sentences to use multiprocessing
 
 
 class StaticModel:

--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -17,7 +17,7 @@ PathLike = Union[Path, str]
 
 logger = getLogger(__name__)
 
-MULTIPROCESSING_THRESHOLD = 6000
+MULTIPROCESSING_THRESHOLD = 10_000
 
 
 class StaticModel:

--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import os
 from logging import getLogger
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -201,8 +202,11 @@ class StaticModel:
         sentence_batches = list(self._batch(sentences, batch_size))
         total_batches = math.ceil(len(sentences) / batch_size)
 
+        # Use joblib for multiprocessing if requested, and if we have enough sentences
         if use_multiprocessing and len(sentences) > MULTIPROCESSING_THRESHOLD:
-            # Use joblib for multiprocessing if requested, and if we have enough sentences
+            # Disable parallelism for tokenizers
+            os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
             results = ProgressParallel(n_jobs=-1, use_tqdm=show_progress_bar, total=total_batches)(
                 delayed(self._encode_batch_as_sequence)(batch, max_length) for batch in sentence_batches
             )
@@ -267,8 +271,11 @@ class StaticModel:
         sentence_batches = list(self._batch(sentences, batch_size))
         total_batches = math.ceil(len(sentences) / batch_size)
 
+        # Use joblib for multiprocessing if requested, and if we have enough sentences
         if use_multiprocessing and len(sentences) > MULTIPROCESSING_THRESHOLD:
-            # Use joblib for multiprocessing if requested, and if we have enough sentences
+            # Disable parallelism for tokenizers
+            os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
             results = ProgressParallel(n_jobs=-1, use_tqdm=show_progress_bar, total=total_batches)(
                 delayed(self._encode_batch)(batch, max_length) for batch in sentence_batches
             )

--- a/model2vec/utils.py
+++ b/model2vec/utils.py
@@ -5,13 +5,48 @@ import re
 from importlib import import_module
 from importlib.metadata import metadata
 from pathlib import Path
-from typing import Iterator, Protocol, cast
+from typing import Any, Iterator, Protocol, cast
 
 import numpy as np
 import safetensors
+from joblib import Parallel
 from tokenizers import Tokenizer
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
+
+
+class ProgressParallel(Parallel):
+    """A drop-in replacement for joblib.Parallel that shows a tqdm progress bar."""
+
+    def __init__(self, use_tqdm: bool = True, total: int | None = None, *args: Any, **kwargs: Any) -> None:
+        """
+        Initialize the ProgressParallel object.
+
+        :param use_tqdm: Whether to show the progress bar.
+        :param total: Total number of tasks (batches) you expect to process. If None,
+                    it updates the total dynamically to the number of dispatched tasks.
+        :param *args: Additional arguments to pass to `Parallel.__init__`.
+        :param **kwargs: Additional keyword arguments to pass to `Parallel.__init__`.
+        """
+        self._use_tqdm = use_tqdm
+        self._total = total
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Create a tqdm context."""
+        with tqdm(disable=not self._use_tqdm, total=self._total) as self._pbar:
+            self._pbar = self._pbar
+            return super().__call__(*args, **kwargs)
+
+    def print_progress(self) -> None:
+        """Hook called by joblib as tasks complete. We update the tqdm bar here."""
+        if self._total is None:
+            # If no fixed total was given, we dynamically set the total
+            self._pbar.total = self.n_dispatched_tasks
+        # Move the bar to the number of completed tasks
+        self._pbar.n = self.n_completed_tasks
+        self._pbar.refresh()
 
 
 class SafeOpenProtocol(Protocol):

--- a/model2vec/utils.py
+++ b/model2vec/utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import json
 import logging
 import re

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 
 dependencies = [
     "jinja2",
+    "joblib",
     "numpy",
     "rich",
     "safetensors",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -66,20 +66,24 @@ def test_encode_single_sentence_empty(
     assert np.all(encoded == 0)
 
 
+@pytest.mark.parametrize("use_multiprocessing", [True, False])
 def test_encode_multiple_sentences(
-    mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
+    use_multiprocessing: bool, mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
 ) -> None:
     """Test encoding of multiple sentences."""
     model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
-    encoded = model.encode(["word1 word2", "word1 word3"])
+    encoded = model.encode(["word1 word2", "word1 word3"], use_multiprocessing=use_multiprocessing)
     assert encoded.shape == (2, 2)
 
 
-def test_encode_as_tokens(mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]) -> None:
+@pytest.mark.parametrize("use_multiprocessing", [True, False])
+def test_encode_as_tokens(
+    use_multiprocessing: bool, mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
+) -> None:
     """Test encoding of sentences as tokens."""
     sentences = ["word1 word2", "word1 word3"]
     model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
-    encoded_sequence = model.encode_as_sequence(sentences)
+    encoded_sequence = model.encode_as_sequence(sentences, use_multiprocessing=use_multiprocessing)
     encoded = model.encode(sentences)
 
     assert len(encoded_sequence) == 2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -66,30 +66,48 @@ def test_encode_single_sentence_empty(
     assert np.all(encoded == 0)
 
 
-@pytest.mark.parametrize("use_multiprocessing", [True, False])
 def test_encode_multiple_sentences(
-    use_multiprocessing: bool, mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
+    mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
 ) -> None:
     """Test encoding of multiple sentences."""
     model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
-    encoded = model.encode(["word1 word2", "word1 word3"], use_multiprocessing=use_multiprocessing)
+    encoded = model.encode(["word1 word2", "word1 word3"])
     assert encoded.shape == (2, 2)
 
 
-@pytest.mark.parametrize("use_multiprocessing", [True, False])
-def test_encode_as_tokens(
-    use_multiprocessing: bool, mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
-) -> None:
+def test_encode_as_sequence(mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]) -> None:
     """Test encoding of sentences as tokens."""
     sentences = ["word1 word2", "word1 word3"]
     model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
-    encoded_sequence = model.encode_as_sequence(sentences, use_multiprocessing=use_multiprocessing)
+    encoded_sequence = model.encode_as_sequence(sentences)
     encoded = model.encode(sentences)
 
     assert len(encoded_sequence) == 2
 
     means = [np.mean(sequence, axis=0) for sequence in encoded_sequence]
     assert np.allclose(means, encoded)
+
+
+def test_encode_multiprocessing(
+    mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
+) -> None:
+    """Test encoding with multiprocessing."""
+    model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
+    # Generate a list of 15k inputs to test multiprocessing
+    sentences = ["word1 word2"] * 15_000
+    encoded = model.encode(sentences, use_multiprocessing=True)
+    assert encoded.shape == (15000, 2)
+
+
+def test_encode_as_sequence_multiprocessing(
+    mock_vectors: np.ndarray, mock_tokenizer: Tokenizer, mock_config: dict[str, str]
+) -> None:
+    """Test encoding of sentences as tokens with multiprocessing."""
+    model = StaticModel(vectors=mock_vectors, tokenizer=mock_tokenizer, config=mock_config)
+    # Generate a list of 15k inputs to test multiprocessing
+    sentences = ["word1 word2"] * 15_000
+    encoded = model.encode_as_sequence(sentences, use_multiprocessing=True)
+    assert len(encoded) == 15_000
 
 
 def test_encode_as_tokens_empty(

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -536,10 +536,11 @@ wheels = [
 
 [[package]]
 name = "model2vec"
-version = "0.3.4"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
+    { name = "joblib" },
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "rich" },
@@ -575,6 +576,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "jinja2" },
+    { name = "joblib" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy" },
     { name = "onnx", marker = "extra == 'onnx'" },
@@ -587,8 +589,8 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'distill'" },
     { name = "setuptools" },
     { name = "tokenizers", specifier = ">=0.20" },
-    { name = "torch", marker = "extra == 'distill'", specifier = "<2.5.0" },
-    { name = "torch", marker = "extra == 'onnx'", specifier = "<2.5.0" },
+    { name = "torch", marker = "extra == 'distill'" },
+    { name = "torch", marker = "extra == 'onnx'" },
     { name = "tqdm" },
     { name = "transformers", marker = "extra == 'distill'" },
 ]
@@ -1625,19 +1627,19 @@ dependencies = [
     { name = "jinja2" },
     { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
     { name = "sympy" },
-    { name = "triton", marker = "python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "python_full_version < '3.13' and platform_machine == 'x86_64' and platform_system == 'Linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -1664,7 +1666,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
Some simple code for benchmarking:

```python
from time import perf_counter

from model2vec import StaticModel
from datasets import load_dataset

def main(use_multiprocessing: bool):
    ds = load_dataset(
        "wikimedia/wikipedia",  
        data_files="20231101.en/train-00000-of-00041.parquet"
    )["train"]
    texts = ds["text"]

    model = StaticModel.from_pretrained("minishlab/potion-base-8M")

    start = perf_counter()
    output = model.encode(
        sentences=texts, 
        show_progress_bar=True, 
        use_multiprocessing=use_multiprocessing,
    )
    total_time = perf_counter() - start

    docs_per_second = len(texts) / total_time
    print(f"Processed {len(texts)} docs in {total_time:.3f}s.")
    print(f"Docs per second: {docs_per_second:.2f}")
    print("Output shape:", output.shape)


if __name__ == "__main__":
    print("Multiprocessing=False")
    main(use_multiprocessing=False)

    print("\nMultiprocessing=True")
    main(use_multiprocessing=True)
```

On my machine, this gives:

```
Multiprocessing=False
Processed 156289 docs in 34.067s.
Docs per second: 4587.69
Output shape: (156289, 256)
```

```
Multiprocessing=True
Processed 156289 docs in 10.407s.
Docs per second: 15017.26
Output shape: (156289, 256)
```

So roughly 3x faster.