### PR TITLE
remove unnecessary import

### DIFF
--- a/model2vec/hf_utils.py
+++ b/model2vec/hf_utils.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import huggingface_hub
-import huggingface_hub.errors
 import numpy as np
 import safetensors
 from huggingface_hub import ModelCard, ModelCardData


### PR DESCRIPTION
Noted by #160, we import `huggingface_hub.errors`, but this doesn't do anything.