### PR TITLE
feat: Add multilabel classification for training

### DIFF
--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -323,7 +323,7 @@ class _ClassifierLightningModule(pl.LightningModule):
         self.learning_rate = learning_rate
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass."""
+        """Simple forward pass."""
         return self.model(x)
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
@@ -342,10 +342,9 @@ class _ClassifierLightningModule(pl.LightningModule):
         x, y = batch
         head_out, _ = self.model(x)
         if self.model.multilabel:
-            # Compute multi-label accuracy by checking if all labels are correct.
             loss = nn.functional.binary_cross_entropy_with_logits(head_out, y.float())
             preds = (torch.sigmoid(head_out) > 0.5).float()
-            # Accuracy is defined as the Jaccard score averaged over samples.
+            # Multilabel accuracy is defined as the Jaccard score averaged over samples.
             accuracy = jaccard_score(y.cpu(), preds.cpu(), average="samples")
         else:
             loss = nn.functional.cross_entropy(head_out, y)

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -141,7 +141,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param batch_size: The batch size. If None, a good batch size is chosen automatically.
         :param min_epochs: The minimum number of epochs to train for.
         :param max_epochs: The maximum number of epochs to train for.
-            If -1, training continues until early stopping is triggered.
+            If this is -1, the model trains until early stopping is triggered.
         :param early_stopping_patience: The patience for early stopping.
             If this is None, early stopping is disabled.
         :param test_size: The test size for the train-test split.

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -47,7 +47,7 @@ class StaticModelForClassification(FinetunableStaticModel):
 
     @property
     def classes(self) -> list[str]:
-        """Return the classes in the correct order."""
+        """Return all clasess in the correct order."""
         return self.classes_
 
     def construct_head(self) -> nn.Sequential:
@@ -142,9 +142,10 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param min_epochs: The minimum number of epochs to train for.
         :param max_epochs: The maximum number of epochs to train for.
             If -1, training continues until early stopping is triggered.
-        :param early_stopping_patience: The patience for early stopping. If None, early stopping is disabled.
+        :param early_stopping_patience: The patience for early stopping.
+            If this is None, early stopping is disabled.
         :param test_size: The test size for the train-test split.
-        :param device: The device to train on. If "auto", the device is chosen automatically.
+        :param device: The device to train on. If this is "auto", the device is chosen automatically.
         :return: The fitted model.
         """
         pl.seed_everything(_RANDOM_SEED)

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from tempfile import TemporaryDirectory
+from typing import cast
 
 import lightning as pl
 import numpy as np
 import torch
 from lightning.pytorch.callbacks import Callback, EarlyStopping
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
+from sklearn.metrics import jaccard_score
 from sklearn.model_selection import train_test_split
 from sklearn.neural_network import MLPClassifier
 from sklearn.pipeline import make_pipeline
@@ -20,7 +22,6 @@ from model2vec.inference import StaticModelPipeline
 from model2vec.train.base import FinetunableStaticModel, TextDataset
 
 logger = logging.getLogger(__name__)
-
 _RANDOM_SEED = 42
 
 
@@ -40,11 +41,13 @@ class StaticModelForClassification(FinetunableStaticModel):
         self.hidden_dim = hidden_dim
         # Alias: Follows scikit-learn. Set to dummy classes
         self.classes_: list[str] = [str(x) for x in range(out_dim)]
+        # multilabel flag will be set based on the type of `y` passed to fit.
+        self.multilabel: bool = False
         super().__init__(vectors=vectors, out_dim=out_dim, pad_id=pad_id, tokenizer=tokenizer)
 
     @property
     def classes(self) -> list[str]:
-        """Return all clasess in the correct order."""
+        """Return the classes in the correct order."""
         return self.classes_
 
     def construct_head(self) -> nn.Sequential:
@@ -67,33 +70,53 @@ class StaticModelForClassification(FinetunableStaticModel):
         return nn.Sequential(*modules)
 
     def predict(self, X: list[str], show_progress_bar: bool = False, batch_size: int = 1024) -> np.ndarray:
-        """Predict a class for a set of texts."""
-        pred: list[str] = []
+        """
+        Predict labels for a set of texts.
+
+        In single-label mode, each prediction is a single class.
+        In multilabel mode, each prediction is a list of classes.
+        """
+        pred = []
         for batch in trange(0, len(X), batch_size, disable=not show_progress_bar):
             logits = self._predict_single_batch(X[batch : batch + batch_size])
-            pred.extend([self.classes[idx] for idx in logits.argmax(1)])
-
-        return np.asarray(pred)
+            if self.multilabel:
+                probs = torch.sigmoid(logits)
+                for sample in probs:
+                    sample_labels = [self.classes[i] for i, p in enumerate(sample) if p > 0.5]
+                    # Fallback: if no label passes the threshold, choose the highest probability label.
+                    if not sample_labels:
+                        sample_labels = [self.classes[sample.argmax().item()]]
+                    pred.append(sample_labels)
+            else:
+                pred.extend([self.classes[idx] for idx in logits.argmax(dim=1).tolist()])
+        return np.array(pred, dtype=object)
 
     @torch.no_grad()
     def _predict_single_batch(self, X: list[str]) -> torch.Tensor:
         input_ids = self.tokenize(X)
-        vectors, _ = self.forward(input_ids)
-        return vectors
+        head_out, _ = self.forward(input_ids)
+        return head_out
 
     def predict_proba(self, X: list[str], show_progress_bar: bool = False, batch_size: int = 1024) -> np.ndarray:
-        """Predict the probability of each class."""
-        pred: list[np.ndarray] = []
+        """
+        Predict probabilities for each class.
+
+        In single-label mode, returns softmax probabilities.
+        In multilabel mode, returns sigmoid probabilities.
+        """
+        pred = []
         for batch in trange(0, len(X), batch_size, disable=not show_progress_bar):
             logits = self._predict_single_batch(X[batch : batch + batch_size])
-            pred.append(torch.softmax(logits, dim=1).numpy())
-
-        return np.concatenate(pred)
+            if self.multilabel:
+                pred.append(torch.sigmoid(logits).cpu().numpy())
+            else:
+                pred.append(torch.softmax(logits, dim=1).cpu().numpy())
+        return np.concatenate(pred, axis=0)
 
     def fit(
         self,
         X: list[str],
-        y: list[str],
+        y: list[str] | list[list[str]],
         learning_rate: float = 1e-3,
         batch_size: int | None = None,
         min_epochs: int | None = None,
@@ -106,43 +129,44 @@ class StaticModelForClassification(FinetunableStaticModel):
         Fit a model.
 
         This function creates a Lightning Trainer object and fits the model to the data.
-        We use early stopping. After training, the weigths of the best model are loaded back into the model.
+        It supports both single-label and multi-label classification.
+        We use early stopping. After training, the weights of the best model are loaded back into the model.
 
-        This function seeds everything with a seed of 42, so the results are reproducible.
-        It also splits the data into a train and validation set, again with a random seed.
+        The function seeds everything with a seed of 42, so the results are reproducible.
+        It also splits the data into training and validation sets using a random seed.
 
         :param X: The texts to train on.
-        :param y: The labels to train on.
+        :param y: The labels to train on. If the first element is a list, multi-label classification is assumed.
         :param learning_rate: The learning rate.
-        :param batch_size: The batch size.
-            If this is None, a good batch size is chosen automatically.
+        :param batch_size: The batch size. If None, a good batch size is chosen automatically.
         :param min_epochs: The minimum number of epochs to train for.
         :param max_epochs: The maximum number of epochs to train for.
-            If this is -1, the model trains until early stopping is triggered.
-        :param early_stopping_patience: The patience for early stopping.
-            If this is None, early stopping is disabled.
+            If -1, training continues until early stopping is triggered.
+        :param early_stopping_patience: The patience for early stopping. If None, early stopping is disabled.
         :param test_size: The test size for the train-test split.
-        :param device: The device to train on. If this is "auto", the device is chosen automatically.
+        :param device: The device to train on. If "auto", the device is chosen automatically.
         :return: The fitted model.
         """
         pl.seed_everything(_RANDOM_SEED)
         logger.info("Re-initializing model.")
-        self._initialize(y)
+
+        # Determine whether we're in multilabel mode based on the first element of y.
+        multilabel = isinstance(y[0], list)
+        self._initialize(y, multilabel=multilabel)
 
         train_texts, validation_texts, train_labels, validation_labels = self._train_test_split(
-            X, y, test_size=test_size
+            X, y, test_size=test_size, multilabel=multilabel
         )
 
         if batch_size is None:
-            # Set to a multiple of 32
             base_number = int(min(max(1, (len(train_texts) / 30) // 32), 16))
             batch_size = int(base_number * 32)
             logger.info("Batch size automatically set to %d.", batch_size)
 
         logger.info("Preparing train dataset.")
-        train_dataset = self._prepare_dataset(train_texts, train_labels)
+        train_dataset = self._prepare_dataset(train_texts, train_labels, multilabel=multilabel)
         logger.info("Preparing validation dataset.")
-        val_dataset = self._prepare_dataset(validation_texts, validation_labels)
+        val_dataset = self._prepare_dataset(validation_texts, validation_labels, multilabel=multilabel)
 
         c = _ClassifierLightningModule(self, learning_rate=learning_rate)
 
@@ -152,8 +176,7 @@ class StaticModelForClassification(FinetunableStaticModel):
             callback = EarlyStopping(monitor="val_accuracy", mode="max", patience=early_stopping_patience)
             callbacks.append(callback)
 
-        # If the dataset is small, we check the validation set every epoch.
-        # If the dataset is large, we check the validation set every 250 batches.
+        # Check validation frequency.
         if n_train_batches < 250:
             val_check_interval = None
             check_val_every_epoch = 1
@@ -186,45 +209,75 @@ class StaticModelForClassification(FinetunableStaticModel):
 
         self.load_state_dict(state_dict)
         self.eval()
-
         return self
 
-    def _initialize(self, y: list[str]) -> None:
-        """Sets the out dimensionality, the classes and initializes the head."""
-        classes = sorted(set(y))
+    def _initialize(self, y: list[str] | list[list[str]], multilabel: bool = False) -> None:
+        """
+        Sets the output dimensionality, the classes, and initializes the head.
+
+        For multilabel classification, y is assumed to be a list of lists.
+        """
+        self.multilabel = multilabel
+        if multilabel:
+            classes = sorted({label for sublist in y for label in sublist})
+        else:
+            classes = sorted(set(cast(list[str], y)))
         self.classes_ = classes
-
-        if len(self.classes) != self.out_dim:
-            self.out_dim = len(self.classes)
-
+        self.out_dim = len(self.classes_)  # Update output dimension
         self.head = self.construct_head()
         self.embeddings = nn.Embedding.from_pretrained(self.vectors.clone(), freeze=False, padding_idx=self.pad_id)
         self.w = self.construct_weights()
         self.train()
 
-    def _prepare_dataset(self, X: list[str], y: list[str], max_length: int = 512) -> TextDataset:
-        """Prepare a dataset."""
-        # This is a speed optimization.
-        # assumes a mean token length of 10, which is really high, so safe.
+    def _prepare_dataset(
+        self, X: list[str], y: list[str] | list[list[str]], max_length: int = 512, multilabel: bool = False
+    ) -> TextDataset:
+        """
+        Prepare a dataset.
+
+        For multilabel classification, each target is converted into a multi-hot vector.
+        """
         truncate_length = max_length * 10
         X = [x[:truncate_length] for x in X]
         tokenized: list[list[int]] = [
             encoding.ids[:max_length] for encoding in self.tokenizer.encode_batch_fast(X, add_special_tokens=False)
         ]
-        labels_tensor = torch.Tensor([self.classes.index(label) for label in y]).long()
-
+        if multilabel:
+            num_classes = len(self.classes)
+            label_list = []
+            for sample_labels in y:
+                multi_hot = torch.zeros(num_classes, dtype=torch.float)
+                for label in sample_labels:
+                    index = self.classes.index(label)
+                    multi_hot[index] = 1.0
+                label_list.append(multi_hot)
+            labels_tensor = torch.stack(label_list)
+        else:
+            labels_tensor = torch.tensor([self.classes.index(label) for label in cast(list[str], y)], dtype=torch.long)
         return TextDataset(tokenized, labels_tensor)
 
     @staticmethod
     def _train_test_split(
-        X: list[str], y: list[str], test_size: float
-    ) -> tuple[list[str], list[str], list[str], list[str]]:
-        """Split the data."""
-        label_counts = Counter(y)
-        if min(label_counts.values()) < 2:
-            logger.info("Some classes have less than 2 samples. Stratification is disabled.")
+        X: list[str],
+        y: list[str] | list[list[str]],
+        test_size: float,
+        multilabel: bool = False,
+    ) -> tuple[list[str], list[str], list[str] | list[list[str]], list[str] | list[list[str]]]:
+        """
+        Split the data.
+
+        For single-label classification, stratification is attempted (if possible).
+        For multilabel classification, a random split is performed.
+        """
+        if not multilabel:
+            label_counts = Counter(y)  # type: ignore
+            if min(label_counts.values()) < 2:
+                logger.info("Some classes have less than 2 samples. Stratification is disabled.")
+                return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True)
+            return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True, stratify=y)
+        else:
+            # Multilabel classification does not support stratification.
             return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True)
-        return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True, stratify=y)
 
     def to_pipeline(self) -> StaticModelPipeline:
         """Convert the model to an sklearn pipeline."""
@@ -256,38 +309,46 @@ class StaticModelForClassification(FinetunableStaticModel):
 
 class _ClassifierLightningModule(pl.LightningModule):
     def __init__(self, model: StaticModelForClassification, learning_rate: float) -> None:
-        """Initialize the lightningmodule."""
+        """Initialize the LightningModule."""
         super().__init__()
         self.model = model
         self.learning_rate = learning_rate
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Simple forward pass."""
+        """Forward pass."""
         return self.model(x)
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
-        """Simple training step using cross entropy loss."""
+        """Training step using cross-entropy loss for single-label and binary cross-entropy for multilabel training."""
         x, y = batch
         head_out, _ = self.model(x)
-        loss = nn.functional.cross_entropy(head_out, y).mean()
-
+        if self.model.multilabel:
+            loss = nn.functional.binary_cross_entropy_with_logits(head_out, y.float())
+        else:
+            loss = nn.functional.cross_entropy(head_out, y)
         self.log("train_loss", loss)
         return loss
 
     def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
-        """Simple validation step using cross entropy loss and accuracy."""
+        """Validation step computing loss and accuracy."""
         x, y = batch
         head_out, _ = self.model(x)
-        loss = nn.functional.cross_entropy(head_out, y).mean()
-        accuracy = (head_out.argmax(1) == y).float().mean()
-
+        if self.model.multilabel:
+            # Compute multi-label accuracy by checking if all labels are correct.
+            loss = nn.functional.binary_cross_entropy_with_logits(head_out, y.float())
+            preds = (torch.sigmoid(head_out) > 0.5).float()
+            # Accuracy is defined as the Jaccard score averaged over samples.
+            accuracy = jaccard_score(y.cpu(), preds.cpu(), average="samples")
+        else:
+            loss = nn.functional.cross_entropy(head_out, y)
+            accuracy = (head_out.argmax(dim=1) == y).float().mean()
         self.log("val_loss", loss)
         self.log("val_accuracy", accuracy, prog_bar=True)
 
         return loss
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
-        """Simple Adam optimizer."""
+        """Configure optimizer and learning rate scheduler."""
         optimizer = torch.optim.Adam(self.model.parameters(), lr=self.learning_rate)
         scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
             optimizer,
@@ -299,5 +360,4 @@ class _ClassifierLightningModule(pl.LightningModule):
             threshold=0.03,
             threshold_mode="rel",
         )
-
         return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "monitor": "val_loss"}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,17 +93,16 @@ def mock_trained_pipeline(request: pytest.FixtureRequest) -> StaticModelForClass
     torch.random.manual_seed(42)
     vectors_torched = torch.randn(len(tokenizer.get_vocab()), 12)
     model = StaticModelForClassification(vectors=vectors_torched, tokenizer=tokenizer, hidden_dim=12).to("cpu")
+
     X = ["dog", "cat"]
     y: list[str] | list[list[str]]
-
     if request.param:
         # Use multilabel targets.
-
         y = [["a", "b"], ["a"]]
     else:
-        # Use single-label targets.
-        X = ["dog", "cat"]
+        # Use singlelabel targets.
         y = ["a", "b"]
+
     model.fit(X, y)
 
     return model

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -112,7 +112,10 @@ def test_textdataset_init_incorrect() -> None:
 def test_predict(mock_trained_pipeline: StaticModelForClassification) -> None:
     """Test the predict function."""
     result = mock_trained_pipeline.predict(["dog cat", "dog"]).tolist()
-    assert result == ["b", "b"]
+    if mock_trained_pipeline.multilabel:
+        assert result == [["a", "b"], ["a", "b"]]
+    else:
+        assert result == ["b", "b"]
 
 
 def test_predict_proba(mock_trained_pipeline: StaticModelForClassification) -> None:


### PR DESCRIPTION
This PR adds multilabel classification to the training module. If labels are passed as a `list[list[str]]`, the model is automatically trained as a multilabel classification model.