### PR TITLE
docs: Update model card template

### DIFF
--- a/model2vec/modelcards/classifier_template.md
+++ b/model2vec/modelcards/classifier_template.md
@@ -27,10 +27,11 @@ predicted = model.predict(["Example sentence"])
 
 ## Additional Resources
 
-- [All Model2Vec models on the hub](https://huggingface.co/models?library=model2vec)
 - [Model2Vec Repo](https://github.com/MinishLab/model2vec)
-- [Model2Vec Results](https://github.com/MinishLab/model2vec?tab=readme-ov-file#results)
+- [Model2Vec Base Models](https://huggingface.co/collections/minishlab/model2vec-base-models-66fd9dd9b7c3b3c0f25ca90e)
+- [Model2Vec Results](https://github.com/MinishLab/model2vec/tree/main/results)
 - [Model2Vec Tutorials](https://github.com/MinishLab/model2vec/tree/main/tutorials)
+- [Website](https://minishlab.github.io/)
 
 ## Library Authors
 
@@ -41,9 +42,9 @@ Model2Vec was developed by the [Minish Lab](https://github.com/MinishLab) team c
 Please cite the [Model2Vec repository](https://github.com/MinishLab/model2vec) if you use this model in your work.
 ```
 @software{minishlab2024model2vec,
-  authors = {Stephan Tulkens, Thomas van Dongen},
-  title = {Model2Vec: Turn any Sentence Transformer into a Small Fast Model},
+  authors = {Stephan Tulkens and Thomas van Dongen},
+  title = {Model2Vec: Fast State-of-the-Art Static Embeddings},
   year = {2024},
-  url = {https://github.com/MinishLab/model2vec},
+  url = {https://github.com/MinishLab/model2vec}
 }
 ```

--- a/model2vec/modelcards/model_card_template.md
+++ b/model2vec/modelcards/model_card_template.md
@@ -4,7 +4,7 @@
 
 # {{ model_name }} Model Card
 
-This [Model2Vec](https://github.com/MinishLab/model2vec) model is a distilled version of {% if base_model %}the {{ base_model }}(https://huggingface.co/{{ base_model }}){% else %}a{% endif %} Sentence Transformer. It uses static embeddings, allowing text embeddings to be computed orders of magnitude faster on both GPU and CPU. It is designed for applications where computational resources are limited or where real-time performance is critical.
+This [Model2Vec](https://github.com/MinishLab/model2vec) model is a distilled version of {% if base_model %}the {{ base_model }}(https://huggingface.co/{{ base_model }}){% else %}a{% endif %} Sentence Transformer. It uses static embeddings, allowing text embeddings to be computed orders of magnitude faster on both GPU and CPU. It is designed for applications where computational resources are limited or where real-time performance is critical. Model2Vec models are the smallest, fastest, and most performant static embedders available. The distilled models are up to 50 times smaller and 500 times faster than traditional Sentence Transformers.
 
 
 ## Installation
@@ -15,6 +15,11 @@ pip install model2vec
 ```
 
 ## Usage
+
+### Using Model2Vec
+
+The [Model2Vec library](https://github.com/MinishLab/model2vec) is the fastest and most lightweight way to run Model2Vec models.
+
 Load this model using the `from_pretrained` method:
 ```python
 from model2vec import StaticModel
@@ -26,15 +31,29 @@ model = StaticModel.from_pretrained("{{ model_name }}")
 embeddings = model.encode(["Example sentence"])
 ```
 
-Alternatively, you can distill your own model using the `distill` method:
+### Using Sentence Transformers
+
+You can also use the [Sentence Transformers library](https://github.com/UKPLab/sentence-transformers) to load and use the model:
+
+```python
+from sentence_transformers import SentenceTransformer
+
+# Load a pretrained Sentence Transformer model
+model = SentenceTransformer("{{ model_name }}")
+
+# Compute text embeddings
+embeddings = model.encode(["Example sentence"])
+```
+
+### Distilling a Model2Vec model
+
+You can distill a Model2Vec model from a Sentence Transformer model using the `distill` method. First, install the `distill` extra with `pip install model2vec[distill]`. Then, run the following code:
+
 ```python
 from model2vec.distill import distill
 
-# Choose a Sentence Transformer model
-model_name = "BAAI/bge-base-en-v1.5"
-
-# Distill the model
-m2v_model = distill(model_name=model_name, pca_dims=256)
+# Distill a Sentence Transformer model, in this case the BAAI/bge-base-en-v1.5 model
+m2v_model = distill(model_name="BAAI/bge-base-en-v1.5", pca_dims=256)
 
 # Save the model
 m2v_model.save_pretrained("m2v_model")
@@ -44,14 +63,16 @@ m2v_model.save_pretrained("m2v_model")
 
 Model2vec creates a small, fast, and powerful model that outperforms other static embedding models by a large margin on all tasks we could find, while being much faster to create than traditional static embedding models such as GloVe. Best of all, you don't need any data to distill a model using Model2Vec.
 
-It works by passing a vocabulary through a sentence transformer model, then reducing the dimensionality of the resulting embeddings using PCA, and finally weighting the embeddings using zipf weighting. During inference, we simply take the mean of all token embeddings occurring in a sentence.
+It works by passing a vocabulary through a sentence transformer model, then reducing the dimensionality of the resulting embeddings using PCA, and finally weighting the embeddings using [SIF weighting](https://openreview.net/pdf?id=SyK00v5xx). During inference, we simply take the mean of all token embeddings occurring in a sentence.
 
 ## Additional Resources
 
-- [All Model2Vec models on the hub](https://huggingface.co/models?library=model2vec)
 - [Model2Vec Repo](https://github.com/MinishLab/model2vec)
-- [Model2Vec Results](https://github.com/MinishLab/model2vec?tab=readme-ov-file#results)
+- [Model2Vec Base Models](https://huggingface.co/collections/minishlab/model2vec-base-models-66fd9dd9b7c3b3c0f25ca90e)
+- [Model2Vec Results](https://github.com/MinishLab/model2vec/tree/main/results)
 - [Model2Vec Tutorials](https://github.com/MinishLab/model2vec/tree/main/tutorials)
+- [Website](https://minishlab.github.io/)
+
 
 ## Library Authors
 
@@ -62,9 +83,9 @@ Model2Vec was developed by the [Minish Lab](https://github.com/MinishLab) team c
 Please cite the [Model2Vec repository](https://github.com/MinishLab/model2vec) if you use this model in your work.
 ```
 @software{minishlab2024model2vec,
-  authors = {Stephan Tulkens, Thomas van Dongen},
-  title = {Model2Vec: Turn any Sentence Transformer into a Small Fast Model},
+  authors = {Stephan Tulkens and Thomas van Dongen},
+  title = {Model2Vec: Fast State-of-the-Art Static Embeddings},
   year = {2024},
-  url = {https://github.com/MinishLab/model2vec},
+  url = {https://github.com/MinishLab/model2vec}
 }
 ```


### PR DESCRIPTION
The model card template had outdated links, and didn't include an example for sentence transformers yet. The citation format was also incorrect. This PR fixes that. Also made a few minor updates to the text.