### PR TITLE
feat: Add evaluate function for classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ from model2vec.train import StaticModelForClassification
 # Initialize a classifier from a pre-trained model
 classifier = StaticModelForClassification.from_pretrained(model_name="minishlab/potion-base-32M")
 
-# Load a dataset
+# Load a dataset. Note: both single and multi-label classification datasets are supported
 ds = load_dataset("setfit/subj")
 
 # Train the classifier on text (X) and labels (y)

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ ds = load_dataset("setfit/subj")
 classifier.fit(ds["train"]["text"], ds["train"]["label"])
 
 # Evaluate the classifier
-predictions = classifier.predict(ds["test"]["text"])
-accuracy = np.mean(np.array(predictions) == np.array(ds["test"]["label"])) * 100
+classification_report = classifier.evaluate(ds["test"]["text"], ds["test"]["label"])
 ```
 
 For advanced usage, please refer to our [usage documentation](https://github.com/MinishLab/model2vec/blob/main/docs/usage.md).

--- a/model2vec/inference/__init__.py
+++ b/model2vec/inference/__init__.py
@@ -5,6 +5,6 @@ _REQUIRED_EXTRA = "inference"
 for extra_dependency in get_package_extras("model2vec", _REQUIRED_EXTRA):
     importable(extra_dependency, _REQUIRED_EXTRA)
 
-from model2vec.inference.model import StaticModelPipeline
+from model2vec.inference.model import StaticModelPipeline, evaluate_single_or_multi_label
 
-__all__ = ["StaticModelPipeline"]
+__all__ = ["StaticModelPipeline", "evaluate_single_or_multi_label"]

--- a/model2vec/inference/model.py
+++ b/model2vec/inference/model.py
@@ -134,7 +134,7 @@ class StaticModelPipeline:
             proba = self.head.predict_proba(encoded)
             for vector in proba:
                 out_labels.append(self.classes_[vector > threshold])
-            return np.asarray(out_labels)
+            return np.asarray(out_labels, dtype=object)
 
         return self.head.predict(encoded)
 

--- a/model2vec/inference/model.py
+++ b/model2vec/inference/model.py
@@ -188,9 +188,7 @@ class StaticModelPipeline:
         :return: A classification report.
         """
         predictions = self.predict(X, show_progress_bar=True, batch_size=batch_size, threshold=threshold)
-        report = evaluate_single_or_multi_label(
-            predictions=predictions, y=y, classes=self.classes_, output_dict=output_dict
-        )
+        report = evaluate_single_or_multi_label(predictions=predictions, y=y, output_dict=output_dict)
 
         return report
 
@@ -279,7 +277,6 @@ def _is_multi_label_shaped(y: LabelType) -> bool:
 def evaluate_single_or_multi_label(
     predictions: np.ndarray,
     y: LabelType,
-    classes: np.ndarray,
     output_dict: bool = False,
 ) -> str | dict[str, dict[str, float]]:
     """
@@ -287,14 +284,16 @@ def evaluate_single_or_multi_label(
 
     :param predictions: The predictions.
     :param y: The ground truth labels.
-    :param classes: The classes of the classifier.
     :param output_dict: Whether to output the classification report as a dictionary.
     :return: A classification report.
     """
     if _is_multi_label_shaped(y):
+        classes = sorted(set([label for labels in y for label in labels]))
         mlb = MultiLabelBinarizer(classes=classes)
         y = mlb.fit_transform(y)
         predictions = mlb.transform(predictions)
+    elif isinstance(y[0], (str, int)):
+        classes = sorted(set(y))
 
     report = classification_report(
         y,

--- a/model2vec/inference/model.py
+++ b/model2vec/inference/model.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import TypeVar
 
 import huggingface_hub
 import numpy as np
 import skops.io
+from sklearn.metrics import classification_report
 from sklearn.neural_network import MLPClassifier
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MultiLabelBinarizer
 
 from model2vec.hf_utils import _create_model_card
 from model2vec.model import PathLike, StaticModel
 
 _DEFAULT_TRUST_PATTERN = re.compile(r"sklearn\..+")
 _DEFAULT_MODEL_FILENAME = "pipeline.skops"
+
+LabelType = TypeVar("LabelType", list[str], list[list[str]])
 
 
 class StaticModelPipeline:
@@ -169,6 +174,26 @@ class StaticModelPipeline:
 
         return self.head.predict_proba(encoded)
 
+    def evaluate(
+        self, X: list[str], y: LabelType, batch_size: int = 1024, threshold: float = 0.5, output_dict: bool = False
+    ) -> str | dict[str, dict[str, float]]:
+        """
+        Evaluate the classifier on a given dataset using scikit-learn's classification report.
+
+        :param X: The texts to predict on.
+        :param y: The ground truth labels.
+        :param batch_size: The batch size.
+        :param threshold: The threshold for multilabel classification.
+        :param output_dict: Whether to output the classification report as a dictionary.
+        :return: A classification report.
+        """
+        predictions = self.predict(X, show_progress_bar=True, batch_size=batch_size, threshold=threshold)
+        report = evaluate_single_or_multi_label(
+            predictions=predictions, y=y, classes=self.classes_, output_dict=output_dict
+        )
+
+        return report
+
 
 def _load_pipeline(
     folder_or_repo_path: PathLike, token: str | None = None, trust_remote_code: bool = False
@@ -244,3 +269,40 @@ def save_pipeline(pipeline: StaticModelPipeline, folder_path: str | Path) -> Non
         language=pipeline.model.language,
         template_path="modelcards/classifier_template.md",
     )
+
+
+def _is_multi_label_shaped(y: LabelType) -> bool:
+    """Check if the labels are in a multi-label shape."""
+    return isinstance(y, (list, tuple)) and len(y) > 0 and isinstance(y[0], (list, tuple, set))
+
+
+def evaluate_single_or_multi_label(
+    predictions: np.ndarray,
+    y: LabelType,
+    classes: np.ndarray,
+    output_dict: bool = False,
+) -> str | dict[str, dict[str, float]]:
+    """
+    Evaluate the classifier on a given dataset using scikit-learn's classification report.
+
+    :param predictions: The predictions.
+    :param y: The ground truth labels.
+    :param classes: The classes of the classifier.
+    :param output_dict: Whether to output the classification report as a dictionary.
+    :return: A classification report.
+    """
+    if _is_multi_label_shaped(y):
+        mlb = MultiLabelBinarizer(classes=classes)
+        y = mlb.fit_transform(y)
+        predictions = mlb.transform(predictions)
+
+    report = classification_report(
+        y,
+        predictions,
+        labels=np.arange(len(classes)),
+        target_names=[str(c) for c in classes],
+        output_dict=output_dict,
+        zero_division=0,
+    )
+
+    return report

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -44,11 +44,10 @@ test = ds["test"]
 s = perf_counter()
 classifier = classifier.fit(train["text"], train["label"])
 
-predicted = classifier.predict(test["text"])
 print(f"Training took {int(perf_counter() - s)} seconds.")
 # Training took 81 seconds
-accuracy = np.mean([x == y for x, y in zip(predicted, test["label"])]) * 100
-print(f"Achieved {accuracy} test accuracy")
+classification_report = classifier.evaluate(ds["test"]["text"], ds["test"]["label"])
+print(classification_report)
 # Achieved 91.0 test accuracy
 ```
 
@@ -95,18 +94,8 @@ Then, we can evaluate the classifier:
 from sklearn import metrics
 from sklearn.preprocessing import MultiLabelBinarizer
 
-# Make predictions on the test set with a threshold of 0.3
-predictions = classifier.predict(ds["test"]["text"], threshold=0.3)
-
-# Evaluate the classifier
-mlb = MultiLabelBinarizer(classes=classifier.classes)
-y_true = mlb.fit_transform(ds["test"]["labels"])
-y_pred = mlb.transform(predictions)
-
-print(f"Accuracy: {metrics.accuracy_score(y_true, y_pred):.3f}")
-print(f"Precision: {metrics.precision_score(y_true, y_pred, average='macro', zero_division=0):.3f}")
-print(f"Recall: {metrics.recall_score(y_true, y_pred, average='macro', zero_division=0):.3f}")
-print(f"F1: {metrics.f1_score(y_true, y_pred, average='macro', zero_division=0):.3f}")
+classification_report = classifier.evaluate(ds["test"]["text"], ds["test"]["labels"], threshold=0.3)
+print(classification_report)
 # Accuracy: 0.410
 # Precision: 0.527
 # Recall: 0.410

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -113,6 +113,8 @@ print(f"F1: {metrics.f1_score(y_true, y_pred, average='macro', zero_division=0):
 # F1: 0.412
 ```
 
+The scores are competetive with the popular [roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions) model, while our model is orders of magnitude faster.
+
 # Persistence
 
 You can turn a classifier into a scikit-learn compatible pipeline, as follows:

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -113,7 +113,7 @@ print(f"F1: {metrics.f1_score(y_true, y_pred, average='macro', zero_division=0):
 # F1: 0.439
 ```
 
-The scores are competetive with the popular [roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions) model, while our model is orders of magnitude faster.
+The scores are competitive with the popular [roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions) model, while our model is orders of magnitude faster.
 
 # Persistence
 

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -69,7 +69,7 @@ print(f"Took {int((perf_counter() - s) * 1000)} milliseconds for {len(test)} ins
 
 ## Multi-label classification
 
-Multi-label classification is supported out of the box. Just pass a list of multi-labels to the `fit` function, and a multi-label classifier will be trained. For example, the following code trains a multi-label classifier on the [go_emotions](https://huggingface.co/datasets/google-research-datasets/go_emotions) dataset:
+Multi-label classification is supported out of the box. Just pass a list of lists to the `fit` function (e.g. `[[label1, label2], [label1, label3]]`), and a multi-label classifier will be trained. For example, the following code trains a multi-label classifier on the [go_emotions](https://huggingface.co/datasets/google-research-datasets/go_emotions) dataset:
 
 ```python
 from datasets import load_dataset

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -95,8 +95,8 @@ Then, we can evaluate the classifier:
 from sklearn import metrics
 from sklearn.preprocessing import MultiLabelBinarizer
 
-# Make predictions on the test set
-predictions = classifier.predict(ds["test"]["text"])
+# Make predictions on the test set with a threshold of 0.3
+predictions = classifier.predict(ds["test"]["text"], threshold=0.3)
 
 # Evaluate the classifier
 mlb = MultiLabelBinarizer(classes=classifier.classes)
@@ -107,10 +107,10 @@ print(f"Accuracy: {metrics.accuracy_score(y_true, y_pred):.3f}")
 print(f"Precision: {metrics.precision_score(y_true, y_pred, average='macro', zero_division=0):.3f}")
 print(f"Recall: {metrics.recall_score(y_true, y_pred, average='macro', zero_division=0):.3f}")
 print(f"F1: {metrics.f1_score(y_true, y_pred, average='macro', zero_division=0):.3f}")
-# Accuracy: 0.488
-# Precision: 0.510
-# Recall: 0.372
-# F1: 0.412
+# Accuracy: 0.410
+# Precision: 0.527
+# Recall: 0.410
+# F1: 0.439
 ```
 
 The scores are competetive with the popular [roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions) model, while our model is orders of magnitude faster.

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -232,7 +232,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         """
         if isinstance(y[0], (str, int)):
             # Check if all labels are strings or integers.
-            if not all(isinstance(label, (str | int)) for label in y):
+            if not all(isinstance(label, (str, int)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be strings or integers.")
             self.multilabel = False
             classes = sorted(set(y))

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -323,7 +323,7 @@ class _ClassifierLightningModule(pl.LightningModule):
         self.learning_rate = learning_rate
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass."""
+        """Simple forward pass."""
         return self.model(x)
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
@@ -342,10 +342,9 @@ class _ClassifierLightningModule(pl.LightningModule):
         x, y = batch
         head_out, _ = self.model(x)
         if self.model.multilabel:
-            # Compute multi-label accuracy by checking if all labels are correct.
             loss = nn.functional.binary_cross_entropy_with_logits(head_out, y.float())
             preds = (torch.sigmoid(head_out) > 0.5).float()
-            # Accuracy is defined as the Jaccard score averaged over samples.
+            # Multilabel accuracy is defined as the Jaccard score averaged over samples.
             accuracy = jaccard_score(y.cpu(), preds.cpu(), average="samples")
         else:
             loss = nn.functional.cross_entropy(head_out, y)

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -141,7 +141,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param batch_size: The batch size. If None, a good batch size is chosen automatically.
         :param min_epochs: The minimum number of epochs to train for.
         :param max_epochs: The maximum number of epochs to train for.
-            If -1, training continues until early stopping is triggered.
+            If this is -1, the model trains until early stopping is triggered.
         :param early_stopping_patience: The patience for early stopping.
             If this is None, early stopping is disabled.
         :param test_size: The test size for the train-test split.

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -231,9 +231,9 @@ class StaticModelForClassification(FinetunableStaticModel):
         :raises ValueError: If the labels are inconsistent.
         """
         if isinstance(y[0], (str, int)):
-            # Check if all labels are strings.
+            # Check if all labels are strings or integers.
             if not all(isinstance(label, (str | int)) for label in y):
-                raise ValueError("Inconsistent label types in y. All labels must be strings.")
+                raise ValueError("Inconsistent label types in y. All labels must be strings or integers.")
             self.multilabel = False
             classes = sorted(set(y))
         else:

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -92,9 +92,8 @@ class StaticModelForClassification(FinetunableStaticModel):
             logits = self._predict_single_batch(X[batch : batch + batch_size])
             if self.multilabel:
                 probs = torch.sigmoid(logits)
-                for sample in probs:
-                    sample_labels = [self.classes[i] for i, p in enumerate(sample) if p > threshold]
-                    pred.append(sample_labels)
+                mask = (probs > threshold).cpu().numpy()
+                pred.extend([np.array(self.classes)[np.flatnonzero(row)] for row in mask])
             else:
                 pred.extend([self.classes[idx] for idx in logits.argmax(dim=1).tolist()])
         return np.array(pred, dtype=object)

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -278,7 +278,7 @@ class StaticModelForClassification(FinetunableStaticModel):
                 indices = [mapping[str(label)] for label in sample_labels]
                 labels_tensor[i, indices] = 1.0
         else:
-            labels_tensor = torch.tensor([self.classes_.index(label) for label in cast(list[str], y)], dtype=torch.long)
+            labels_tensor = torch.tensor([self.classes_.index(str(label)) for label in y], dtype=torch.long)
         return TextDataset(tokenized, labels_tensor)
 
     def _train_test_split(

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -242,9 +242,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         """
         self.eval()
         predictions = self.predict(X, show_progress_bar=True, batch_size=batch_size, threshold=threshold)
-        report = evaluate_single_or_multi_label(
-            predictions=predictions, y=y, classes=self.classes, output_dict=output_dict
-        )
+        report = evaluate_single_or_multi_label(predictions=predictions, y=y, output_dict=output_dict)
 
         return report
 

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -231,18 +231,14 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param y: The labels.
         :raises ValueError: If the labels are inconsistent.
         """
-        if not y:
-            raise ValueError("y must not be empty")
-
-        first_label = y[0]
-        if isinstance(first_label, str):
+        if isinstance(y[0], str):
             # Now we know y should be a list of strings.
             if not all(isinstance(label, str) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be strings.")
             self.multilabel = False
             y_single: list[str] = y  # Now mypy knows this is a list of strings.
             classes = sorted(set(y_single))
-        elif isinstance(first_label, (list, tuple)):
+        elif isinstance(y[0], (list, tuple)):
             # Now we know y should be a list of lists/tuples.
             if not all(isinstance(label, (list, tuple)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be lists or tuples.")

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -49,9 +49,9 @@ class StaticModelForClassification(FinetunableStaticModel):
         super().__init__(vectors=vectors, out_dim=out_dim, pad_id=pad_id, tokenizer=tokenizer)
 
     @property
-    def classes(self) -> list[str]:
+    def classes(self) -> np.ndarray:
         """Return all clasess in the correct order."""
-        return self.classes_
+        return np.array(self.classes_)
 
     def construct_head(self) -> nn.Sequential:
         """Constructs a simple classifier head."""
@@ -93,7 +93,7 @@ class StaticModelForClassification(FinetunableStaticModel):
             if self.multilabel:
                 probs = torch.sigmoid(logits)
                 mask = (probs > threshold).cpu().numpy()
-                pred.extend([np.array(self.classes)[np.flatnonzero(row)] for row in mask])
+                pred.extend([self.classes[np.flatnonzero(row)] for row in mask])
             else:
                 pred.extend([self.classes[idx] for idx in logits.argmax(dim=1).tolist()])
         return np.array(pred, dtype=object)
@@ -275,7 +275,7 @@ class StaticModelForClassification(FinetunableStaticModel):
                 indices = [mapping[label] for label in sample_labels]
                 labels_tensor[i, indices] = 1.0
         else:
-            labels_tensor = torch.tensor([self.classes.index(label) for label in cast(list[str], y)], dtype=torch.long)
+            labels_tensor = torch.tensor([self.classes_.index(label) for label in cast(list[str], y)], dtype=torch.long)
         return TextDataset(tokenized, labels_tensor)
 
     def _train_test_split(

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -47,7 +47,7 @@ class StaticModelForClassification(FinetunableStaticModel):
 
     @property
     def classes(self) -> list[str]:
-        """Return the classes in the correct order."""
+        """Return all clasess in the correct order."""
         return self.classes_
 
     def construct_head(self) -> nn.Sequential:
@@ -142,9 +142,10 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param min_epochs: The minimum number of epochs to train for.
         :param max_epochs: The maximum number of epochs to train for.
             If -1, training continues until early stopping is triggered.
-        :param early_stopping_patience: The patience for early stopping. If None, early stopping is disabled.
+        :param early_stopping_patience: The patience for early stopping.
+            If this is None, early stopping is disabled.
         :param test_size: The test size for the train-test split.
-        :param device: The device to train on. If "auto", the device is chosen automatically.
+        :param device: The device to train on. If this is "auto", the device is chosen automatically.
         :return: The fitted model.
         """
         pl.seed_everything(_RANDOM_SEED)

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -25,7 +25,7 @@ from model2vec.train.base import FinetunableStaticModel, TextDataset
 logger = logging.getLogger(__name__)
 _RANDOM_SEED = 42
 
-LabelType = TypeVar("LabelType", list[str], list[list[str]])
+LabelType = TypeVar("LabelType", list[str | int], list[list[str | int]])
 
 
 class StaticModelForClassification(FinetunableStaticModel):
@@ -230,18 +230,18 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param y: The labels.
         :raises ValueError: If the labels are inconsistent.
         """
-        if isinstance(y[0], str):
+        if isinstance(y[0], (str, int)):
             # Check if all labels are strings.
-            if not all(isinstance(label, str) for label in y):
+            if not all(isinstance(label, (str, int)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be strings.")
             self.multilabel = False
-            classes = sorted(set(y))
+            classes = sorted({str(label) for label in y})
         else:
             # Check if all labels are lists or tuples.
             if not all(isinstance(label, (list, tuple)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be lists or tuples.")
             self.multilabel = True
-            classes = sorted(set(chain.from_iterable(y)))
+            classes = sorted({str(label) for label in chain.from_iterable(y)})
 
         self.classes_ = classes
         self.out_dim = len(self.classes_)  # Update output dimension
@@ -258,6 +258,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param y: The labels.
         :param max_length: The maximum length of the input.
         :return: A TextDataset.
+        :raises ValueError: If the labels are inconsistent.
         """
         # This is a speed optimization.
         # assumes a mean token length of 10, which is really high, so safe.
@@ -272,7 +273,9 @@ class StaticModelForClassification(FinetunableStaticModel):
             labels_tensor = torch.zeros(len(y), num_classes, dtype=torch.float)
             mapping = {label: idx for idx, label in enumerate(self.classes_)}
             for i, sample_labels in enumerate(y):
-                indices = [mapping[label] for label in sample_labels]
+                if not isinstance(sample_labels, (list, tuple)):
+                    raise ValueError("For multilabel classification, each label should be a list or tuple.")
+                indices = [mapping[str(label)] for label in sample_labels]
                 labels_tensor[i, indices] = 1.0
         else:
             labels_tensor = torch.tensor([self.classes_.index(label) for label in cast(list[str], y)], dtype=torch.long)
@@ -281,7 +284,7 @@ class StaticModelForClassification(FinetunableStaticModel):
     def _train_test_split(
         self,
         X: list[str],
-        y: list[str] | list[list[str]],
+        y: LabelType,
         test_size: float,
     ) -> tuple[list[str], list[str], LabelType, LabelType]:
         """

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -91,9 +91,6 @@ class StaticModelForClassification(FinetunableStaticModel):
                 probs = torch.sigmoid(logits)
                 for sample in probs:
                     sample_labels = [self.classes[i] for i, p in enumerate(sample) if p > threshold]
-                    # Fallback: if no label passes the threshold, choose the highest probability label.
-                    if not sample_labels:
-                        sample_labels = [self.classes[sample.argmax().item()]]
                     pred.append(sample_labels)
             else:
                 pred.extend([self.classes[idx] for idx in logits.argmax(dim=1).tolist()])

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from tempfile import TemporaryDirectory
+from typing import cast
 
 import lightning as pl
 import numpy as np
 import torch
 from lightning.pytorch.callbacks import Callback, EarlyStopping
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
+from sklearn.metrics import jaccard_score
 from sklearn.model_selection import train_test_split
 from sklearn.neural_network import MLPClassifier
 from sklearn.pipeline import make_pipeline
@@ -20,7 +22,6 @@ from model2vec.inference import StaticModelPipeline
 from model2vec.train.base import FinetunableStaticModel, TextDataset
 
 logger = logging.getLogger(__name__)
-
 _RANDOM_SEED = 42
 
 
@@ -40,11 +41,13 @@ class StaticModelForClassification(FinetunableStaticModel):
         self.hidden_dim = hidden_dim
         # Alias: Follows scikit-learn. Set to dummy classes
         self.classes_: list[str] = [str(x) for x in range(out_dim)]
+        # multilabel flag will be set based on the type of `y` passed to fit.
+        self.multilabel: bool = False
         super().__init__(vectors=vectors, out_dim=out_dim, pad_id=pad_id, tokenizer=tokenizer)
 
     @property
     def classes(self) -> list[str]:
-        """Return all clasess in the correct order."""
+        """Return the classes in the correct order."""
         return self.classes_
 
     def construct_head(self) -> nn.Sequential:
@@ -67,33 +70,53 @@ class StaticModelForClassification(FinetunableStaticModel):
         return nn.Sequential(*modules)
 
     def predict(self, X: list[str], show_progress_bar: bool = False, batch_size: int = 1024) -> np.ndarray:
-        """Predict a class for a set of texts."""
-        pred: list[str] = []
+        """
+        Predict labels for a set of texts.
+
+        In single-label mode, each prediction is a single class.
+        In multilabel mode, each prediction is a list of classes.
+        """
+        pred = []
         for batch in trange(0, len(X), batch_size, disable=not show_progress_bar):
             logits = self._predict_single_batch(X[batch : batch + batch_size])
-            pred.extend([self.classes[idx] for idx in logits.argmax(1)])
-
-        return np.asarray(pred)
+            if self.multilabel:
+                probs = torch.sigmoid(logits)
+                for sample in probs:
+                    sample_labels = [self.classes[i] for i, p in enumerate(sample) if p > 0.5]
+                    # Fallback: if no label passes the threshold, choose the highest probability label.
+                    if not sample_labels:
+                        sample_labels = [self.classes[sample.argmax().item()]]
+                    pred.append(sample_labels)
+            else:
+                pred.extend([self.classes[idx] for idx in logits.argmax(dim=1).tolist()])
+        return np.array(pred, dtype=object)
 
     @torch.no_grad()
     def _predict_single_batch(self, X: list[str]) -> torch.Tensor:
         input_ids = self.tokenize(X)
-        vectors, _ = self.forward(input_ids)
-        return vectors
+        head_out, _ = self.forward(input_ids)
+        return head_out
 
     def predict_proba(self, X: list[str], show_progress_bar: bool = False, batch_size: int = 1024) -> np.ndarray:
-        """Predict the probability of each class."""
-        pred: list[np.ndarray] = []
+        """
+        Predict probabilities for each class.
+
+        In single-label mode, returns softmax probabilities.
+        In multilabel mode, returns sigmoid probabilities.
+        """
+        pred = []
         for batch in trange(0, len(X), batch_size, disable=not show_progress_bar):
             logits = self._predict_single_batch(X[batch : batch + batch_size])
-            pred.append(torch.softmax(logits, dim=1).numpy())
-
-        return np.concatenate(pred)
+            if self.multilabel:
+                pred.append(torch.sigmoid(logits).cpu().numpy())
+            else:
+                pred.append(torch.softmax(logits, dim=1).cpu().numpy())
+        return np.concatenate(pred, axis=0)
 
     def fit(
         self,
         X: list[str],
-        y: list[str],
+        y: list[str] | list[list[str]],
         learning_rate: float = 1e-3,
         batch_size: int | None = None,
         min_epochs: int | None = None,
@@ -106,43 +129,44 @@ class StaticModelForClassification(FinetunableStaticModel):
         Fit a model.
 
         This function creates a Lightning Trainer object and fits the model to the data.
-        We use early stopping. After training, the weigths of the best model are loaded back into the model.
+        It supports both single-label and multi-label classification.
+        We use early stopping. After training, the weights of the best model are loaded back into the model.
 
-        This function seeds everything with a seed of 42, so the results are reproducible.
-        It also splits the data into a train and validation set, again with a random seed.
+        The function seeds everything with a seed of 42, so the results are reproducible.
+        It also splits the data into training and validation sets using a random seed.
 
         :param X: The texts to train on.
-        :param y: The labels to train on.
+        :param y: The labels to train on. If the first element is a list, multi-label classification is assumed.
         :param learning_rate: The learning rate.
-        :param batch_size: The batch size.
-            If this is None, a good batch size is chosen automatically.
+        :param batch_size: The batch size. If None, a good batch size is chosen automatically.
         :param min_epochs: The minimum number of epochs to train for.
         :param max_epochs: The maximum number of epochs to train for.
-            If this is -1, the model trains until early stopping is triggered.
-        :param early_stopping_patience: The patience for early stopping.
-            If this is None, early stopping is disabled.
+            If -1, training continues until early stopping is triggered.
+        :param early_stopping_patience: The patience for early stopping. If None, early stopping is disabled.
         :param test_size: The test size for the train-test split.
-        :param device: The device to train on. If this is "auto", the device is chosen automatically.
+        :param device: The device to train on. If "auto", the device is chosen automatically.
         :return: The fitted model.
         """
         pl.seed_everything(_RANDOM_SEED)
         logger.info("Re-initializing model.")
-        self._initialize(y)
+
+        # Determine whether we're in multilabel mode based on the first element of y.
+        multilabel = isinstance(y[0], list)
+        self._initialize(y, multilabel=multilabel)
 
         train_texts, validation_texts, train_labels, validation_labels = self._train_test_split(
-            X, y, test_size=test_size
+            X, y, test_size=test_size, multilabel=multilabel
         )
 
         if batch_size is None:
-            # Set to a multiple of 32
             base_number = int(min(max(1, (len(train_texts) / 30) // 32), 16))
             batch_size = int(base_number * 32)
             logger.info("Batch size automatically set to %d.", batch_size)
 
         logger.info("Preparing train dataset.")
-        train_dataset = self._prepare_dataset(train_texts, train_labels)
+        train_dataset = self._prepare_dataset(train_texts, train_labels, multilabel=multilabel)
         logger.info("Preparing validation dataset.")
-        val_dataset = self._prepare_dataset(validation_texts, validation_labels)
+        val_dataset = self._prepare_dataset(validation_texts, validation_labels, multilabel=multilabel)
 
         c = _ClassifierLightningModule(self, learning_rate=learning_rate)
 
@@ -152,8 +176,7 @@ class StaticModelForClassification(FinetunableStaticModel):
             callback = EarlyStopping(monitor="val_accuracy", mode="max", patience=early_stopping_patience)
             callbacks.append(callback)
 
-        # If the dataset is small, we check the validation set every epoch.
-        # If the dataset is large, we check the validation set every 250 batches.
+        # Check validation frequency.
         if n_train_batches < 250:
             val_check_interval = None
             check_val_every_epoch = 1
@@ -186,45 +209,75 @@ class StaticModelForClassification(FinetunableStaticModel):
 
         self.load_state_dict(state_dict)
         self.eval()
-
         return self
 
-    def _initialize(self, y: list[str]) -> None:
-        """Sets the out dimensionality, the classes and initializes the head."""
-        classes = sorted(set(y))
+    def _initialize(self, y: list[str] | list[list[str]], multilabel: bool = False) -> None:
+        """
+        Sets the output dimensionality, the classes, and initializes the head.
+
+        For multilabel classification, y is assumed to be a list of lists.
+        """
+        self.multilabel = multilabel
+        if multilabel:
+            classes = sorted({label for sublist in y for label in sublist})
+        else:
+            classes = sorted(set(cast(list[str], y)))
         self.classes_ = classes
-
-        if len(self.classes) != self.out_dim:
-            self.out_dim = len(self.classes)
-
+        self.out_dim = len(self.classes_)  # Update output dimension
         self.head = self.construct_head()
         self.embeddings = nn.Embedding.from_pretrained(self.vectors.clone(), freeze=False, padding_idx=self.pad_id)
         self.w = self.construct_weights()
         self.train()
 
-    def _prepare_dataset(self, X: list[str], y: list[str], max_length: int = 512) -> TextDataset:
-        """Prepare a dataset."""
-        # This is a speed optimization.
-        # assumes a mean token length of 10, which is really high, so safe.
+    def _prepare_dataset(
+        self, X: list[str], y: list[str] | list[list[str]], max_length: int = 512, multilabel: bool = False
+    ) -> TextDataset:
+        """
+        Prepare a dataset.
+
+        For multilabel classification, each target is converted into a multi-hot vector.
+        """
         truncate_length = max_length * 10
         X = [x[:truncate_length] for x in X]
         tokenized: list[list[int]] = [
             encoding.ids[:max_length] for encoding in self.tokenizer.encode_batch_fast(X, add_special_tokens=False)
         ]
-        labels_tensor = torch.Tensor([self.classes.index(label) for label in y]).long()
-
+        if multilabel:
+            num_classes = len(self.classes)
+            label_list = []
+            for sample_labels in y:
+                multi_hot = torch.zeros(num_classes, dtype=torch.float)
+                for label in sample_labels:
+                    index = self.classes.index(label)
+                    multi_hot[index] = 1.0
+                label_list.append(multi_hot)
+            labels_tensor = torch.stack(label_list)
+        else:
+            labels_tensor = torch.tensor([self.classes.index(label) for label in cast(list[str], y)], dtype=torch.long)
         return TextDataset(tokenized, labels_tensor)
 
     @staticmethod
     def _train_test_split(
-        X: list[str], y: list[str], test_size: float
-    ) -> tuple[list[str], list[str], list[str], list[str]]:
-        """Split the data."""
-        label_counts = Counter(y)
-        if min(label_counts.values()) < 2:
-            logger.info("Some classes have less than 2 samples. Stratification is disabled.")
+        X: list[str],
+        y: list[str] | list[list[str]],
+        test_size: float,
+        multilabel: bool = False,
+    ) -> tuple[list[str], list[str], list[str] | list[list[str]], list[str] | list[list[str]]]:
+        """
+        Split the data.
+
+        For single-label classification, stratification is attempted (if possible).
+        For multilabel classification, a random split is performed.
+        """
+        if not multilabel:
+            label_counts = Counter(y)  # type: ignore
+            if min(label_counts.values()) < 2:
+                logger.info("Some classes have less than 2 samples. Stratification is disabled.")
+                return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True)
+            return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True, stratify=y)
+        else:
+            # Multilabel classification does not support stratification.
             return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True)
-        return train_test_split(X, y, test_size=test_size, random_state=42, shuffle=True, stratify=y)
 
     def to_pipeline(self) -> StaticModelPipeline:
         """Convert the model to an sklearn pipeline."""
@@ -256,38 +309,46 @@ class StaticModelForClassification(FinetunableStaticModel):
 
 class _ClassifierLightningModule(pl.LightningModule):
     def __init__(self, model: StaticModelForClassification, learning_rate: float) -> None:
-        """Initialize the lightningmodule."""
+        """Initialize the LightningModule."""
         super().__init__()
         self.model = model
         self.learning_rate = learning_rate
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Simple forward pass."""
+        """Forward pass."""
         return self.model(x)
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
-        """Simple training step using cross entropy loss."""
+        """Training step using cross-entropy loss for single-label and binary cross-entropy for multilabel training."""
         x, y = batch
         head_out, _ = self.model(x)
-        loss = nn.functional.cross_entropy(head_out, y).mean()
-
+        if self.model.multilabel:
+            loss = nn.functional.binary_cross_entropy_with_logits(head_out, y.float())
+        else:
+            loss = nn.functional.cross_entropy(head_out, y)
         self.log("train_loss", loss)
         return loss
 
     def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
-        """Simple validation step using cross entropy loss and accuracy."""
+        """Validation step computing loss and accuracy."""
         x, y = batch
         head_out, _ = self.model(x)
-        loss = nn.functional.cross_entropy(head_out, y).mean()
-        accuracy = (head_out.argmax(1) == y).float().mean()
-
+        if self.model.multilabel:
+            # Compute multi-label accuracy by checking if all labels are correct.
+            loss = nn.functional.binary_cross_entropy_with_logits(head_out, y.float())
+            preds = (torch.sigmoid(head_out) > 0.5).float()
+            # Accuracy is defined as the Jaccard score averaged over samples.
+            accuracy = jaccard_score(y.cpu(), preds.cpu(), average="samples")
+        else:
+            loss = nn.functional.cross_entropy(head_out, y)
+            accuracy = (head_out.argmax(dim=1) == y).float().mean()
         self.log("val_loss", loss)
         self.log("val_accuracy", accuracy, prog_bar=True)
 
         return loss
 
     def configure_optimizers(self) -> OptimizerLRScheduler:
-        """Simple Adam optimizer."""
+        """Configure optimizer and learning rate scheduler."""
         optimizer = torch.optim.Adam(self.model.parameters(), lr=self.learning_rate)
         scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
             optimizer,
@@ -299,5 +360,4 @@ class _ClassifierLightningModule(pl.LightningModule):
             threshold=0.03,
             threshold_mode="rel",
         )
-
         return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "monitor": "val_loss"}}

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -236,17 +236,13 @@ class StaticModelForClassification(FinetunableStaticModel):
             if not all(isinstance(label, str) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be strings.")
             self.multilabel = False
-            # y_single: list[str] = y
             classes = sorted(set(y))
-        elif isinstance(y[0], (list, tuple)):
+        else:
             # Check if all labels are lists or tuples.
             if not all(isinstance(label, (list, tuple)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be lists or tuples.")
             self.multilabel = True
-            # y_multilabel: list[list[str]] = y  # mypy now knows this is a list of lists.
             classes = sorted(set(chain.from_iterable(y)))
-        else:
-            raise ValueError("Labels must be either strings or lists/tuples of strings.")
 
         self.classes_ = classes
         self.out_dim = len(self.classes_)  # Update output dimension

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -232,40 +232,21 @@ class StaticModelForClassification(FinetunableStaticModel):
         :raises ValueError: If the labels are inconsistent.
         """
         if isinstance(y[0], str):
-            # Now we know y should be a list of strings.
+            # Check if all labels are strings.
             if not all(isinstance(label, str) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be strings.")
             self.multilabel = False
-            y_single: list[str] = y  # Now mypy knows this is a list of strings.
-            classes = sorted(set(y_single))
+            # y_single: list[str] = y
+            classes = sorted(set(y))
         elif isinstance(y[0], (list, tuple)):
-            # Now we know y should be a list of lists/tuples.
+            # Check if all labels are lists or tuples.
             if not all(isinstance(label, (list, tuple)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be lists or tuples.")
             self.multilabel = True
-            y_multilabel: list[list[str]] = y  # mypy now knows this is a list of lists.
-            classes = sorted(set(chain.from_iterable(y_multilabel)))
+            # y_multilabel: list[list[str]] = y  # mypy now knows this is a list of lists.
+            classes = sorted(set(chain.from_iterable(y)))
         else:
             raise ValueError("Labels must be either strings or lists/tuples of strings.")
-
-        # # Determine multilabel status by checking the type of each element in y.
-        # if any(isinstance(label, (list, tuple)) for label in y):
-        #     if not all(isinstance(label, (list, tuple)) for label in y):
-        #         raise ValueError("Inconsistent label types in y. All labels must be either singular or list/tuple.")
-        #     self.multilabel = True
-        #     y_multilabel: list[list[str]] = y
-        #     classes = sorted(set(chain.from_iterable(y_multilabel)))
-        # else:
-        #     self.multilabel = False
-        #     y_single: list[str] = y
-        #     classes = sorted(set(y_single))
-
-        # self.multilabel = multilabel
-        # if multilabel:
-        #     # Flatten the labels
-        #     classes = sorted(set(chain.from_iterable(y)))
-        # else:
-        #     classes = sorted(set(cast(list[str], y)))
 
         self.classes_ = classes
         self.out_dim = len(self.classes_)  # Update output dimension

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -11,11 +11,10 @@ import numpy as np
 import torch
 from lightning.pytorch.callbacks import Callback, EarlyStopping
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
-from sklearn.metrics import classification_report, jaccard_score
+from sklearn.metrics import jaccard_score
 from sklearn.model_selection import train_test_split
 from sklearn.neural_network import MLPClassifier
 from sklearn.pipeline import make_pipeline
-from sklearn.preprocessing import MultiLabelBinarizer
 from tokenizers import Tokenizer
 from torch import nn
 from tqdm import trange

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -323,8 +323,8 @@ class StaticModelForClassification(FinetunableStaticModel):
         # To convert correctly, we need to set the outputs correctly, and fix the activation function.
         # Make sure n_outputs is set to > 1.
         mlp_head.n_outputs_ = self.out_dim
-        # Set to softmax
-        mlp_head.out_activation_ = "softmax"
+        # Set to softmax or sigmoid
+        mlp_head.out_activation_ = "logistic" if self.multilabel else "softmax"
 
         return StaticModelPipeline(static_model, converted)
 
@@ -373,7 +373,6 @@ class _ClassifierLightningModule(pl.LightningModule):
             mode="min",
             factor=0.5,
             patience=3,
-            verbose=True,
             min_lr=1e-6,
             threshold=0.03,
             threshold_mode="rel",

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -230,9 +230,9 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param y: The labels.
         :raises ValueError: If the labels are inconsistent.
         """
-        if isinstance(y[0], str):
+        if isinstance(y[0], (str, int)):
             # Check if all labels are strings.
-            if not all(isinstance(label, str) for label in y):
+            if not all(isinstance(label, (str | int)) for label in y):
                 raise ValueError("Inconsistent label types in y. All labels must be strings.")
             self.multilabel = False
             classes = sorted(set(y))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,12 @@ from typing import Any
 import numpy as np
 import pytest
 import torch
-from sklearn.neural_network import MLPClassifier
-from sklearn.pipeline import make_pipeline
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
 from tokenizers.pre_tokenizers import Whitespace
 from transformers import AutoModel, AutoTokenizer
 
 from model2vec.inference import StaticModelPipeline
-from model2vec.model import StaticModel
 from model2vec.train import StaticModelForClassification
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,17 +93,16 @@ def mock_trained_pipeline(request: pytest.FixtureRequest) -> StaticModelForClass
     torch.random.manual_seed(42)
     vectors_torched = torch.randn(len(tokenizer.get_vocab()), 12)
     model = StaticModelForClassification(vectors=vectors_torched, tokenizer=tokenizer, hidden_dim=12).to("cpu")
+
     X = ["dog", "cat"]
     y: list[str] | list[list[str]]
-
     if request.param:
         # Use multilabel targets.
-
         y = [["a", "b"], ["a"]]
     else:
-        # Use single-label targets.
-        X = ["dog", "cat"]
+        # Use singlelabel targets.
         y = ["a", "b"]
+
     model.fit(X, y)
 
     return model

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -10,8 +10,13 @@ from model2vec.inference import StaticModelPipeline
 
 def test_init_predict(mock_inference_pipeline: StaticModelPipeline) -> None:
     """Test successful initialization of StaticModelPipeline."""
-    assert mock_inference_pipeline.predict("dog").tolist() == ["b"]
-    assert mock_inference_pipeline.predict(["dog"]).tolist() == ["b"]
+    target: list[str] | list[list[str]]
+    if mock_inference_pipeline.multilabel:
+        target = [["a", "b"]]
+    else:
+        target = ["b"]
+    assert mock_inference_pipeline.predict("dog").tolist() == target
+    assert mock_inference_pipeline.predict(["dog"]).tolist() == target
 
 
 def test_init_predict_proba(mock_inference_pipeline: StaticModelPipeline) -> None:
@@ -25,8 +30,13 @@ def test_roundtrip_save(mock_inference_pipeline: StaticModelPipeline) -> None:
     with TemporaryDirectory() as temp_dir:
         mock_inference_pipeline.save_pretrained(temp_dir)
         loaded = StaticModelPipeline.from_pretrained(temp_dir)
-        assert loaded.predict("dog") == ["b"]
-        assert loaded.predict(["dog"]) == ["b"]
+        target: list[str] | list[list[str]]
+        if mock_inference_pipeline.multilabel:
+            target = [["a", "b"]]
+        else:
+            target = ["b"]
+        assert loaded.predict("dog").tolist() == target
+        assert loaded.predict(["dog"]).tolist() == target
         assert loaded.predict_proba("dog").argmax() == 1
         assert loaded.predict_proba(["dog"]).argmax(1).tolist() == [1]
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -9,7 +9,7 @@ from model2vec.inference import StaticModelPipeline
 
 
 def test_init_predict(mock_inference_pipeline: StaticModelPipeline) -> None:
-    """Test successful initialization of StaticModelPipeline."""
+    """Test successful init and predict with StaticModelPipeline."""
     target: list[str] | list[list[str]]
     if mock_inference_pipeline.multilabel:
         if isinstance(mock_inference_pipeline.classes_[0], str):
@@ -26,9 +26,25 @@ def test_init_predict(mock_inference_pipeline: StaticModelPipeline) -> None:
 
 
 def test_init_predict_proba(mock_inference_pipeline: StaticModelPipeline) -> None:
-    """Test successful initialization of StaticModelPipeline."""
+    """Test successful init and predict_proba with StaticModelPipeline."""
     assert mock_inference_pipeline.predict_proba("dog").argmax() == 1
     assert mock_inference_pipeline.predict_proba(["dog"]).argmax(1).tolist() == [1]
+
+
+def test_init_evaluate(mock_inference_pipeline: StaticModelPipeline) -> None:
+    """Test successful init and evaluate with StaticModelPipeline."""
+    target: list[str] | list[list[str]]
+    if mock_inference_pipeline.multilabel:
+        if isinstance(mock_inference_pipeline.classes_[0], str):
+            target = [["a", "b"]]
+        else:
+            target = [[0, 1]]  # type: ignore
+    else:
+        if isinstance(mock_inference_pipeline.classes_[0], str):
+            target = ["b"]
+        else:
+            target = [1]  # type: ignore
+    mock_inference_pipeline.evaluate("dog", target)  # type: ignore
 
 
 def test_roundtrip_save(mock_inference_pipeline: StaticModelPipeline) -> None:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -12,9 +12,15 @@ def test_init_predict(mock_inference_pipeline: StaticModelPipeline) -> None:
     """Test successful initialization of StaticModelPipeline."""
     target: list[str] | list[list[str]]
     if mock_inference_pipeline.multilabel:
-        target = [["a", "b"]]
+        if isinstance(mock_inference_pipeline.classes_[0], str):
+            target = [["a", "b"]]
+        else:
+            target = [[0, 1]]  # type: ignore
     else:
-        target = ["b"]
+        if isinstance(mock_inference_pipeline.classes_[0], str):
+            target = ["b"]
+        else:
+            target = [1]  # type: ignore
     assert mock_inference_pipeline.predict("dog").tolist() == target
     assert mock_inference_pipeline.predict(["dog"]).tolist() == target
 
@@ -32,9 +38,15 @@ def test_roundtrip_save(mock_inference_pipeline: StaticModelPipeline) -> None:
         loaded = StaticModelPipeline.from_pretrained(temp_dir)
         target: list[str] | list[list[str]]
         if mock_inference_pipeline.multilabel:
-            target = [["a", "b"]]
+            if isinstance(mock_inference_pipeline.classes_[0], str):
+                target = [["a", "b"]]
+            else:
+                target = [[0, 1]]  # type: ignore
         else:
-            target = ["b"]
+            if isinstance(mock_inference_pipeline.classes_[0], str):
+                target = ["b"]
+            else:
+                target = [1]  # type: ignore
         assert loaded.predict("dog").tolist() == target
         assert loaded.predict(["dog"]).tolist() == target
         assert loaded.predict_proba("dog").argmax() == 1

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -112,7 +112,10 @@ def test_textdataset_init_incorrect() -> None:
 def test_predict(mock_trained_pipeline: StaticModelForClassification) -> None:
     """Test the predict function."""
     result = mock_trained_pipeline.predict(["dog cat", "dog"]).tolist()
-    assert result == ["b", "b"]
+    if mock_trained_pipeline.multilabel:
+        assert result == [["a", "b"], ["a", "b"]]
+    else:
+        assert result == ["b", "b"]
 
 
 def test_predict_proba(mock_trained_pipeline: StaticModelForClassification) -> None:

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -113,9 +113,15 @@ def test_predict(mock_trained_pipeline: StaticModelForClassification) -> None:
     """Test the predict function."""
     result = mock_trained_pipeline.predict(["dog cat", "dog"]).tolist()
     if mock_trained_pipeline.multilabel:
-        assert result == [["a", "b"], ["a", "b"]]
+        if type(mock_trained_pipeline.classes_[0]) == str:
+            assert result == [["a", "b"], ["a", "b"]]
+        else:
+            assert result == [[0, 1], [0, 1]]
     else:
-        assert result == ["b", "b"]
+        if type(mock_trained_pipeline.classes_[0]) == str:
+            assert result == ["b", "b"]
+        else:
+            assert result == [1, 1]
 
 
 def test_predict_proba(mock_trained_pipeline: StaticModelForClassification) -> None:
@@ -146,3 +152,19 @@ def test_train_test_split(mock_trained_pipeline: StaticModelForClassification) -
     assert len(b) == 2
     assert len(c) == len(a)
     assert len(d) == len(b)
+
+
+def test_evaluate(mock_trained_pipeline: StaticModelForClassification) -> None:
+    """Test the evaluate function."""
+    if mock_trained_pipeline.multilabel:
+        if type(mock_trained_pipeline.classes_[0]) == str:
+            mock_trained_pipeline.evaluate(["dog cat", "dog"], [["a", "b"], ["a"]])
+        else:
+            # Ignore the type error since we don't support int labels in our typing, but the code does
+            mock_trained_pipeline.evaluate(["dog cat", "dog"], [[0, 1], [0]])  # type: ignore
+    else:
+        if type(mock_trained_pipeline.classes_[0]) == str:
+            mock_trained_pipeline.evaluate(["dog cat", "dog"], ["a", "a"])
+        else:
+            # Ignore the type error since we don't support int labels in our typing, but the code does
+            mock_trained_pipeline.evaluate(["dog cat", "dog"], [1, 1])  # type: ignore

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -17,8 +17,8 @@ def test_init_predict(n_layers: int, mock_vectors: np.ndarray, mock_tokenizer: T
     s = StaticModelForClassification(vectors=vectors_torched, tokenizer=mock_tokenizer, n_layers=n_layers)
     assert s.vectors.shape == mock_vectors.shape
     assert s.w.shape[0] == mock_vectors.shape[0]
-    assert s.classes == s.classes_
-    assert s.classes == ["0", "1"]
+    assert list(s.classes) == s.classes_
+    assert list(s.classes) == ["0", "1"]
 
     head = s.construct_head()
     assert head[0].in_features == mock_vectors.shape[1]

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -139,9 +139,9 @@ def test_convert_to_pipeline(mock_trained_pipeline: StaticModelForClassification
     assert np.allclose(p1, p2)
 
 
-def test_train_test_split() -> None:
+def test_train_test_split(mock_trained_pipeline: StaticModelForClassification) -> None:
     """Test the train test split function."""
-    a, b, c, d = StaticModelForClassification._train_test_split(["0", "1", "2", "3"], ["1", "1", "0", "0"], 0.5)
+    a, b, c, d = mock_trained_pipeline._train_test_split(["0", "1", "2", "3"], ["1", "1", "0", "0"], 0.5)
     assert len(a) == 2
     assert len(b) == 2
     assert len(c) == len(a)

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ wheels = [
 
 [[package]]
 name = "model2vec"
-version = "0.3.8"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
This PR adds an `evaluate` function that can be used after fitting a classifier. It returns an sklearn classification report. It works for both multi and single label inputs, and str and int type labels. This makes it a bit easier to evaluate a model by abstracting away the logic for binarizing labels in the multilabel case, and in general provides a nice natural flow, e.g.:
```python
# Load a model
classifier = StaticModelForClassification.from_pretrained(model_name="minishlab/potion-base-32M")
# Load a dataset
ds = load_dataset("setfit/subj")
# Fit 
classifier.fit(ds["train"]["text"], ds["train"]["label"], max_epochs=1)
# Evaluate
print(classifier.evaluate(ds["test"]["text"], ds["test"]["label"]))
```

The tests are also updated to include int type labels. While our typing doesn't officially support list[int], many of the datasets we benchmarked on have int type labels, and not including that in the tests is dangerous (I accidentally broke the int label logic in my previous PR but our tests didn't catch that, now they will). In a followup we can think about potentially updating our typing.