### PR TITLE
feat: Add classifier explainability based on token importance

### DIFF
--- a/model2vec/inference/__init__.py
+++ b/model2vec/inference/__init__.py
@@ -5,6 +5,11 @@ _REQUIRED_EXTRA = "inference"
 for extra_dependency in get_package_extras("model2vec", _REQUIRED_EXTRA):
     importable(extra_dependency, _REQUIRED_EXTRA)
 
-from model2vec.inference.model import StaticModelPipeline, evaluate_single_or_multi_label
+from model2vec.inference.model import (
+    StaticModelPipeline,
+    compute_token_logits,
+    evaluate_single_or_multi_label,
+    get_most_important_tokens,
+)
 
-__all__ = ["StaticModelPipeline", "evaluate_single_or_multi_label"]
+__all__ = ["StaticModelPipeline", "evaluate_single_or_multi_label", "compute_token_logits", "get_most_important_tokens"]

--- a/model2vec/inference/__init__.py
+++ b/model2vec/inference/__init__.py
@@ -7,9 +7,8 @@ for extra_dependency in get_package_extras("model2vec", _REQUIRED_EXTRA):
 
 from model2vec.inference.model import (
     StaticModelPipeline,
-    compute_token_logits,
     evaluate_single_or_multi_label,
     get_most_important_tokens,
 )
 
-__all__ = ["StaticModelPipeline", "evaluate_single_or_multi_label", "compute_token_logits", "get_most_important_tokens"]
+__all__ = ["StaticModelPipeline", "evaluate_single_or_multi_label", "get_most_important_tokens"]

--- a/model2vec/inference/model.py
+++ b/model2vec/inference/model.py
@@ -49,11 +49,6 @@ class StaticModelPipeline:
         self.model.normalize = value
 
     @property
-    def embeddings(self) -> np.ndarray:
-        """Get the embeddings of the model."""
-        return self.model.embedding
-
-    @property
     def tokenizer(self) -> str:
         """Get the tokenizer of the model."""
         return self.model.tokenizer
@@ -411,6 +406,6 @@ def get_most_important_tokens(model: Any, token_logits: dict[int, np.ndarray], t
         logit = float(token_logit[label_idx])
         results.append((token_str, logit))
 
-    # Sort tokens by descending importance.
+    # Sort tokens by descending importance
     results.sort(key=lambda x: x[1], reverse=True)
     return results

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -106,7 +106,7 @@ The scores are competitive with the popular [roberta-base-go_emotions](https://h
 
 ## Explainability
 
-We offer a simple explainability method that allows you to see the most important tokens for a prediction. This is based on the logit outputs for the tokens in the input text, which we extract by forward passing them individually through the trained classifier. Since our classifier is a simple mean embedding followed by a single linear layer (meaning there is interaction between tokens), this is a good approximation of the importance of each token. The following code example shows how this works:
+We offer a simple explainability method that allows you to see the most important tokens for a prediction. This is based on the logit outputs for the tokens in the input text, which we extract by forward passing them individually through the trained classifier. Since our classifier is a simple mean embedding followed by a single linear layer (meaning there is no interaction between tokens), this is a good approximation of the importance of each token. The following code example shows how this works:
 
 ```python
 from datasets import load_dataset

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -115,7 +115,7 @@ from model2vec.train import StaticModelForClassification
 # Initialize a classifier from a pre-trained model
 classifier = StaticModelForClassification.from_pretrained(model_name="minishlab/potion-base-32M")
 
-# Load a multi-label dataset
+# Load a dataset, in this case the (multi-label) Reuters dataset
 ds = load_dataset("ucirvine/reuters21578", "ModApte")
 
 # Train the classifier on text (X) and labels (y)

--- a/model2vec/train/README.md
+++ b/model2vec/train/README.md
@@ -106,7 +106,7 @@ The scores are competitive with the popular [roberta-base-go_emotions](https://h
 
 ## Explainability
 
-We offer a simple explainability method that allows you to see the most important tokens for a prediction. This is based on the logit outputs for the tokens in the input text, which we extract by forward passing them individually through the trained classifier. Since our classifier is a simple mean embedding followed by a single linear layer (meaning there is no interaction between tokens), this is a good approximation of the importance of each token. The following code example shows how this works:
+We offer a simple explainability method that allows you to see the most important tokens for a prediction: `get_most_important_tokens`. This is based on the logit outputs for the tokens in the input text, which we extract by forward passing them individually through the trained classifier. Since our classifier is a simple mean embedding followed by a single linear layer (meaning there is no interaction between tokens), this is a good approximation of the importance of each token. The following code example shows how this works:
 
 ```python
 from datasets import load_dataset

--- a/model2vec/train/base.py
+++ b/model2vec/train/base.py
@@ -27,6 +27,7 @@ class FinetunableStaticModel(nn.Module):
         self.out_dim = out_dim
         self.embed_dim = vectors.shape[1]
         self.vectors = vectors
+        self.normalize = True
 
         self.embeddings = nn.Embedding.from_pretrained(vectors.clone().float(), freeze=False, padding_idx=pad_id)
         self.head = self.construct_head()
@@ -85,7 +86,8 @@ class FinetunableStaticModel(nn.Module):
         embedded = torch.bmm(w[:, None, :], embedded).squeeze(1)
         # Mean pooling by dividing by the length
         embedded = embedded / length[:, None]
-
+        if not self.normalize:
+            return embedded
         return nn.functional.normalize(embedded)
 
     def forward(self, input_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/model2vec/train/base.py
+++ b/model2vec/train/base.py
@@ -86,9 +86,9 @@ class FinetunableStaticModel(nn.Module):
         embedded = torch.bmm(w[:, None, :], embedded).squeeze(1)
         # Mean pooling by dividing by the length
         embedded = embedded / length[:, None]
-        if not self.normalize:
-            return embedded
-        return nn.functional.normalize(embedded)
+        if self.normalize:
+            nn.functional.normalize(embedded)
+        return embedded
 
     def forward(self, input_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass through the mean, and a classifier layer after."""

--- a/model2vec/train/base.py
+++ b/model2vec/train/base.py
@@ -87,7 +87,7 @@ class FinetunableStaticModel(nn.Module):
         # Mean pooling by dividing by the length
         embedded = embedded / length[:, None]
         if self.normalize:
-            nn.functional.normalize(embedded)
+            return nn.functional.normalize(embedded)
         return embedded
 
     def forward(self, input_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -54,16 +54,6 @@ class StaticModelForClassification(FinetunableStaticModel):
         self.token_logits: dict[int, np.ndarray] | None = None
         super().__init__(vectors=vectors, out_dim=out_dim, pad_id=pad_id, tokenizer=tokenizer)
 
-    def compute_token_logits(self) -> None:
-        """Compute the output logits for each token in the vocabulary."""
-        self.token_logits = compute_token_logits(self)
-
-    def get_most_important_tokens(self, text: str) -> list[tuple[str, float]]:
-        """Get the token scores for the predicted label."""
-        if self.token_logits is None:
-            raise ValueError("Token logits are not computed. Run compute_token_logits first to use this function.")
-        return get_most_important_tokens(self, token_logits=self.token_logits, text=text)
-
     @property
     def classes(self) -> np.ndarray:
         """Return all clasess in the correct order."""
@@ -265,6 +255,16 @@ class StaticModelForClassification(FinetunableStaticModel):
         report = evaluate_single_or_multi_label(predictions=predictions, y=y, output_dict=output_dict)
 
         return report
+
+    def compute_token_logits(self) -> None:
+        """Compute the output logits for each token in the vocabulary."""
+        self.token_logits = compute_token_logits(self)
+
+    def get_most_important_tokens(self, text: str) -> list[tuple[str, float]]:
+        """Get the token scores for the predicted label."""
+        if self.token_logits is None:
+            self.token_logits = compute_token_logits(self)
+        return get_most_important_tokens(self, token_logits=self.token_logits, text=text)
 
     def _initialize(self, y: LabelType) -> None:
         """

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -120,8 +120,16 @@ class StaticModelForClassification(FinetunableStaticModel):
         """
         Predict probabilities for each class.
 
-        In single-label mode, returns softmax probabilities.
-        In multilabel mode, returns sigmoid probabilities.
+        This function outputs:
+        - Softmax probabilities in single-label mode.
+        - Sigmoid probabilities in multilabel mode.
+        - Logits if `output_logits` is True.
+
+        :param X: The texts to predict on.
+        :param show_progress_bar: Whether to show a progress bar.
+        :param batch_size: The batch size.
+        :param output_logits: Whether to output logits.
+        :return: The probabilities.
         """
         pred = []
         for batch in trange(0, len(X), batch_size, disable=not show_progress_bar):

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -409,7 +409,7 @@ class _ClassifierLightningModule(pl.LightningModule):
         if self.model.multilabel:
             preds = (torch.sigmoid(head_out) > 0.5).float()
             # Multilabel accuracy is defined as the Jaccard score averaged over samples.
-            accuracy = jaccard_score(y.cpu(), preds.cpu(), average="samples")
+            accuracy = jaccard_score(y.cpu(), preds.cpu(), average="samples", zero_division=0)
         else:
             accuracy = (head_out.argmax(dim=1) == y).float().mean()
         self.log("val_loss", loss)

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -101,7 +101,7 @@ class StaticModelForClassification(FinetunableStaticModel):
             # Get the token string and logits
             token_str = self.tokenizer.id_to_token(token_id)
             token_logits = self.token_logits.get(token_id)
-            if not token_logits:
+            if token_logits is None:
                 continue
             # Get the score for the predicted label
             logit = float(token_logits[label_idx])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -86,3 +86,12 @@ def test_roundtrip_save_file_gone(mock_inference_pipeline: StaticModelPipeline) 
         os.unlink(os.path.join(temp_dir, "pipeline.skops"))
         with pytest.raises(FileNotFoundError):
             StaticModelPipeline.from_pretrained(temp_dir)
+
+
+def test_get_most_important_tokens(mock_inference_pipeline: StaticModelPipeline) -> None:
+    """The the get_most_important_tokens function."""
+    with pytest.raises(ValueError):
+        mock_inference_pipeline.get_most_important_tokens(text="dog cat")
+    mock_inference_pipeline.compute_token_logits()
+    result = mock_inference_pipeline.get_most_important_tokens(text="dog cat")
+    assert len(result) == 2

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -90,8 +90,5 @@ def test_roundtrip_save_file_gone(mock_inference_pipeline: StaticModelPipeline) 
 
 def test_get_most_important_tokens(mock_inference_pipeline: StaticModelPipeline) -> None:
     """The the get_most_important_tokens function."""
-    with pytest.raises(ValueError):
-        mock_inference_pipeline.get_most_important_tokens(text="dog cat")
-    mock_inference_pipeline.compute_token_logits()
     result = mock_inference_pipeline.get_most_important_tokens(text="dog cat")
     assert len(result) == 2

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -173,7 +173,7 @@ def test_evaluate(mock_trained_pipeline: StaticModelForClassification) -> None:
 def test_get_most_important_tokens(mock_trained_pipeline: StaticModelForClassification) -> None:
     """The the get_most_important_tokens function."""
     with pytest.raises(ValueError):
-        mock_trained_pipeline.get_most_important_tokens("dog cat")
+        mock_trained_pipeline.get_most_important_tokens(text="dog cat")
     mock_trained_pipeline.compute_token_logits()
-    result = mock_trained_pipeline.get_most_important_tokens("dog cat")
+    result = mock_trained_pipeline.get_most_important_tokens(text="dog cat")
     assert len(result) == 2

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -168,3 +168,12 @@ def test_evaluate(mock_trained_pipeline: StaticModelForClassification) -> None:
         else:
             # Ignore the type error since we don't support int labels in our typing, but the code does
             mock_trained_pipeline.evaluate(["dog cat", "dog"], [1, 1])  # type: ignore
+
+
+def test_get_most_important_tokens(mock_trained_pipeline: StaticModelForClassification) -> None:
+    """The the get_most_important_tokens function."""
+    with pytest.raises(ValueError):
+        mock_trained_pipeline.get_most_important_tokens("dog cat")
+    mock_trained_pipeline.compute_token_logits()
+    result = mock_trained_pipeline.get_most_important_tokens("dog cat")
+    assert len(result) == 2

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -172,8 +172,5 @@ def test_evaluate(mock_trained_pipeline: StaticModelForClassification) -> None:
 
 def test_get_most_important_tokens(mock_trained_pipeline: StaticModelForClassification) -> None:
     """The the get_most_important_tokens function."""
-    with pytest.raises(ValueError):
-        mock_trained_pipeline.get_most_important_tokens(text="dog cat")
-    mock_trained_pipeline.compute_token_logits()
     result = mock_trained_pipeline.get_most_important_tokens(text="dog cat")
     assert len(result) == 2


### PR DESCRIPTION
This PR adds explainability for classifiers by sorting the tokens of the input based on output layer logits for the predicted class. Couple of open questions/concerns:
- I feel like this adds even more functions (on top of the evaluate functions) to inference/model.py Is this the best place to add functions that are shared between inference/model.py and train/classifier.py, or should we have a utils.py or something similar? In the inference module makes sense since that's also installed when installing the train module, but perhaps a different file for functions that are shared between the two makes sense.
- Right now, if token_logits do not exist, they are computed when `get_most_important_tokens` is called. I think this is fine since it's really fast, but should we log this, or is it ok as is?
- typing for the model is set to Any since we get some nasty circular import stuff if we want to type it correctly, but maybe the lord of the types knows how to fix this 👀 