### PR TITLE
fix: Updated semantic chunking tutorial 

### DIFF
--- a/tutorials/semantic_chunking.ipynb
+++ b/tutorials/semantic_chunking.ipynb
@@ -18,8 +18,15 @@
    "outputs": [],
    "source": [
     "# Install the necessary libraries\n",
-    "!pip install datasets model2vec numpy tqdm vicinity\n",
-    "\n",
+    "!pip install -q datasets model2vec numpy tqdm vicinity \"chonkie[semantic]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Import the necessary libraries\n",
     "import random \n",
     "import re\n",
@@ -43,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,25 +86,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of chunks: 6148\n",
-      "Time taken: 2.2917541670030914\n"
+      "Number of chunks: 4436\n",
+      "Time taken: 1.6311538339941762\n"
      ]
     }
    ],
    "source": [
     "# Initialize a SemanticChunker from Chonkie with the potion-base-8M model\n",
     "chunker = SDPMChunker(\n",
-    "    embedding_model=\"minishlab/potion-base-8M\",\n",
-    "    similarity_threshold=0.3,\n",
-    "    skip_window=5,\n",
-    "    chunk_size = 256\n",
+    "    embedding_model=\"minishlab/potion-base-32M\",\n",
+    "    chunk_size = 512, \n",
+    "    skip_window=5, \n",
+    "    min_sentences=3\n",
     ")\n",
     "\n",
     "# Chunk the text\n",
@@ -116,18 +123,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " Hard as it was for Princess  Mary to emerge from the realm of secluded contemplation in which she  had lived till then, and sorry and almost ashamed as she felt to leave  Natásha alone, yet the cares of life demanded her attention and she  involuntarily yielded to them. She went through the accounts with  Alpátych, conferred with Dessalles about her nephew, and gave orders and  made preparations for the journey to Moscow. Natásha remained alone and, from the time Princess Mary began making  preparations for departure, held aloof from her too. Princess Mary asked the countess to let Natásha go with her to Moscow,  and both parents gladly accepted this offer, for they saw their daughter  losing strength every day and thought that a change of scene and the  advice of Moscow doctors would be good for her. “I am not going anywhere,” Natásha replied when this was proposed to  her. “Do please just leave me alone! ” And she ran out of the room, with  difficulty refraining from tears of vexation and irritation rather than  of sorrow. \n",
+      " Wait and we shall  see! As if fighting were fun. They are  like children from whom one can’t get any sensible account of what has  happened because they all want to show how well they can fight. But  that’s not what is needed now. “And what ingenious maneuvers they all propose to me! \n",
       "\n",
-      " In all these words she saw only that the danger  threatening her son would not soon be over. \n",
+      " The first thing he saw on riding up to the space  where Túshin’s guns were stationed was an unharnessed horse with a  broken leg, that lay screaming piteously beside the harnessed horses. Blood was gushing from its leg as from a spring. Among the limbers lay  several dead men. \n",
       "\n",
-      " When later on in his memoirs Count Rostopchín explained his actions at  this time, he repeatedly says that he was then actuated by two important  considerations: to maintain tranquillity in Moscow and expedite the  departure of the inhabitants. If one accepts this twofold aim all  Rostopchín’s actions appear irreproachable. “Why were the holy relics,  the arms, ammunition, gunpowder, and stores of corn not removed? Why  were thousands of inhabitants deceived into believing that Moscow would  not be given up—and thereby ruined? \n",
+      " Out of an army  of a hundred thousand we must expect at least twenty thousand wounded,  and we haven’t stretchers, or bunks, or dressers, or doctors enough for  six thousand. We have ten thousand carts, but we need other things as  well—we must manage as best we can! ”    The strange thought that of the thousands of men, young and old, who  had stared with merry surprise at his hat (perhaps the very men he had  noticed), twenty thousand were inevitably doomed to wounds and death  amazed Pierre. “They may die tomorrow; why are they thinking of anything but death? ”  And by some latent sequence of thought the descent of the Mozháysk hill,  the carts with the wounded, the ringing bells, the slanting rays of the  sun, and the songs of the cavalrymen vividly recurred to his mind. “The cavalry ride to battle and meet the wounded and do not for a moment  think of what awaits them, but pass by, winking at the wounded. Yet from  among these men twenty thousand are doomed to die, and they wonder at my  hat! ” thought Pierre, continuing his way to Tatárinova. \n",
       "\n"
      ]
     }
@@ -150,21 +157,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 1.5817922909918707\n"
+      "Time taken: 2.269912125004339\n"
      ]
     }
    ],
    "source": [
     "# Initialize an embedding model and encode the chunk texts\n",
     "time = perf_counter()\n",
-    "model = StaticModel.from_pretrained(\"minishlab/potion-base-8M\")\n",
+    "model = StaticModel.from_pretrained(\"minishlab/potion-base-32M\")\n",
     "chunk_texts = [chunk.text for chunk in chunks]\n",
     "chunk_embeddings = model.encode(chunk_texts)\n",
     "\n",
@@ -184,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -193,27 +200,27 @@
      "text": [
       "Query: Emperor Napoleon\n",
       "--------------------------------------------------\n",
-      " In 1808 the Emperor Alexander went to Erfurt for a fresh interview with  the Emperor Napoleon, and in the upper circles of Petersburg there was  much talk of the grandeur of this important meeting. CHAPTER XXII    In 1809 the intimacy between “the world’s two arbiters,” as  Napoleon and Alexander were called, was such that when Napoleon declared  war on Austria a Russian corps crossed the frontier to co-operate with  our old enemy Bonaparte against our old ally the Emperor of Austria, and  in court circles the possibility of marriage between Napoleon and one  of Alexander’s sisters was spoken of. \n",
+      " In 1808 the Emperor Alexander went to Erfurt for a fresh interview with  the Emperor Napoleon, and in the upper circles of Petersburg there was  much talk of the grandeur of this important meeting. CHAPTER XXII    In 1809 the intimacy between “the world’s two arbiters,” as  Napoleon and Alexander were called, was such that when Napoleon declared  war on Austria a Russian corps crossed the frontier to co-operate with  our old enemy Bonaparte against our old ally the Emperor of Austria, and  in court circles the possibility of marriage between Napoleon and one  of Alexander’s sisters was spoken of. But besides considerations of  foreign policy, the attention of Russian society was at that time keenly  directed on the internal changes that were being undertaken in all the  departments of government. Life meanwhile—real life, with its essential interests of health and  sickness, toil and rest, and its intellectual interests in thought,  science, poetry, music, love, friendship, hatred, and passions—went on  as usual, independently of and apart from political friendship or enmity  with Napoleon Bonaparte and from all the schemes of reconstruction. BOOK SIX: 1808 - 10            CHAPTER I    Prince Andrew had spent two years continuously in the country. All the plans Pierre had attempted on his estates—and constantly  changing from one thing to another had never accomplished—were carried  out by Prince Andrew without display and without perceptible difficulty. \n",
       "\n",
-      " ) “It’s in the Emperor’s  service. \n",
+      " CHAPTER XXVI    On August 25, the eve of the battle of Borodinó, M. de Beausset, prefect  of the French Emperor’s palace, arrived at Napoleon’s quarters at  Valúevo with Colonel Fabvier, the former from Paris and the latter from  Madrid. Donning his court uniform, M. de Beausset ordered a box he had  brought for the Emperor to be carried before him and entered the first  compartment of Napoleon’s tent, where he began opening the box while  conversing with Napoleon’s aides-de-camp who surrounded him. Fabvier, not entering the tent, remained at the entrance talking to some  generals of his acquaintance. The Emperor Napoleon had not yet left his bedroom and was finishing his  toilet. \n",
       "\n",
-      " “The day before yesterday it was ‘Napoléon, France,  bravoure’; yesterday, ‘Alexandre, Russie, grandeur. ’ One day our  Emperor gives it and next day Napoleon. Tomorrow our Emperor will send  a St. \n",
+      " In Russia there  was an Emperor, Alexander, who decided to restore order in Europe and  therefore fought against Napoleon. In 1807 he suddenly made friends  with him, but in 1811 they again quarreled and again began killing many  people. Napoleon led six hundred thousand men into Russia and captured  Moscow; then he suddenly ran away from Moscow, and the Emperor  Alexander, helped by the advice of Stein and others, united Europe to  arm against the disturber of its peace. All Napoleon’s allies suddenly  became his enemies and their forces advanced against the fresh forces he  raised. The Allies defeated Napoleon, entered Paris, forced Napoleon to  abdicate, and sent him to the island of Elba, not depriving him of the  title of Emperor and showing him every respect, though five years before  and one year later they all regarded him as an outlaw and a brigand. Then Louis XVIII, who till then had been the laughingstock both of the  French and the Allies, began to reign. And Napoleon, shedding tears  before his Old Guards, renounced the throne and went into exile. \n",
       "\n",
       "Query: The battle of Austerlitz\n",
       "--------------------------------------------------\n",
-      " On the first arrival of the news of the battle of Austerlitz, Moscow had  been bewildered. \n",
+      " Behave as you did at  Austerlitz, Friedland, Vítebsk, and Smolénsk. Let our remotest posterity  recall your achievements this day with pride. Let it be said of each of  you: “He was in the great battle before Moscow! \n",
       "\n",
-      " That  city is taken; the Russian army suffers heavier losses than the opposing  armies had suffered in the former war from Austerlitz to Wagram. \n",
+      " By a strange coincidence, this task, which turned out to be a most  difficult and important one, was entrusted to Dokhtúrov—that same modest  little Dokhtúrov whom no one had described to us as drawing up plans  of battles, dashing about in front of regiments, showering crosses on  batteries, and so on, and who was thought to be and was spoken of as  undecided and undiscerning—but whom we find commanding wherever the  position was most difficult all through the Russo-French wars from  Austerlitz to the year 1813. At Austerlitz he remained last at the  Augezd dam, rallying the regiments, saving what was possible when all  were flying and perishing and not a single general was left in the rear  guard. Ill with fever he went to Smolénsk with twenty thousand men  to defend the town against Napoleon’s whole army. \n",
       "\n",
-      " Behave as you did at  Austerlitz, Friedland, Vítebsk, and Smolénsk. \n",
+      " “Nothing is truer or sadder. These gentlemen ride onto the bridge alone and wave white handkerchiefs;  they assure the officer on duty that they, the marshals, are on  their way to negotiate with Prince Auersperg. He lets them enter the  tête-de-pont. * They spin him a thousand gasconades, saying that  the war is over, that the Emperor Francis is arranging a meeting with  Bonaparte, that they desire to see Prince Auersperg, and so on. The  officer sends for Auersperg; these gentlemen embrace the officers, crack  jokes, sit on the cannon, and meanwhile a French battalion gets to  the bridge unobserved, flings the bags of incendiary material into  the water, and approaches the tête-de-pont. At length appears the  lieutenant general, our dear Prince Auersperg von Mautern himself. Flower of the Austrian army, hero of the Turkish wars! Hostilities are ended, we can shake one another’s hand. The  Emperor Napoleon burns with impatience to make Prince Auersperg’s  acquaintance. \n",
       "\n",
       "Query: Paris\n",
       "--------------------------------------------------\n",
-      " A man who doesn’t know Paris  is a savage. You can tell a Parisian two leagues off. Paris is Talma, la  Duchénois, Potier, the Sorbonne, the boulevards,” and noticing that  his conclusion was weaker than what had gone before, he added quickly:  “There is only one Paris in the world. You have been to Paris and have  remained Russian. \n",
+      " Paris is Talma, la  Duchénois, Potier, the Sorbonne, the boulevards,” and noticing that  his conclusion was weaker than what had gone before, he added quickly:  “There is only one Paris in the world. You have been to Paris and have  remained Russian. Well, I don’t esteem you the less for it. \n",
       "\n",
-      " Well, what is Paris saying? \n",
+      " Look at  our youths, look at our ladies! The French are our Gods: Paris is our  Kingdom of Heaven. ”    He began speaking louder, evidently to be heard by everyone. “French dresses, French ideas, French feelings! \n",
       "\n",
-      " Paris would have been the capital of the world, and the French the envy  of the nations! \n",
+      " “Oh yes, one sees that plainly. A man who doesn’t know Paris  is a savage. You can tell a Parisian two leagues off. \n",
       "\n"
      ]
     }
@@ -239,7 +246,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "3.10.12",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -253,9 +260,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
# TL;DR

Add "chonkie[semantic]" to the installs and add the new chunking params during init of the `SemanticChunker`. Also use `potion-base-32M` for improved chunk quality. 

# Copilot summary

This pull request includes updates to the `tutorials/semantic_chunking.ipynb` file to improve the tutorial's functionality and performance. The most important changes include updating the library installation command, modifying the model used for chunking, and adjusting the execution counts and outputs for various cells.

Library and model updates:

* Updated the library installation command to include the `chonkie[semantic]` package.
* Changed the embedding model from `minishlab/potion-base-8M` to `minishlab/potion-base-32M` and adjusted chunking parameters for better performance.

Execution counts and outputs:

* Updated execution counts for multiple cells to reflect the new order of execution. [[1]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L46-R53) [[2]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L119-R137) [[3]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L153-R174) [[4]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L187-R194)
* Modified the outputs of cells to reflect the new chunking results and performance metrics. [[1]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L82-R107) [[2]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L153-R174)

Metadata updates:

* Updated the kernel display name and Python version in the notebook metadata. [[1]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L242-R249) [[2]](diffhunk://#diff-85ac9c46a71dade727d0d840a67851a66089c9a844e21bda034dbb9e57d604f0L256-R267)