### PR TITLE
rewrite backend

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -293,7 +293,7 @@ def _post_process_embeddings(
     return embeddings
 
 
-def _clean_vocabulary(tokenizer: Tokenizer, preprocessed_vocabulary: list[str], added_tokens: list[str]) -> list[str]:
+def _clean_vocabulary(tokenizer: Tokenizer, vocabulary: list[str], added_tokens: list[str]) -> list[str]:
     """Cleans a vocabulary by removing duplicates and tokens that were already in the vocabulary."""
     added_tokens_set = set(added_tokens)
     seen_tokens = set()
@@ -301,7 +301,7 @@ def _clean_vocabulary(tokenizer: Tokenizer, preprocessed_vocabulary: list[str], 
     n_empty = 0
     n_duplicates = 0
     n_multiword = 0
-    for token in preprocessed_vocabulary:
+    for token in vocabulary:
         if tokenizer.normalizer is not None:
             token = tokenizer.normalizer.normalize_str(token)
 
@@ -312,10 +312,13 @@ def _clean_vocabulary(tokenizer: Tokenizer, preprocessed_vocabulary: list[str], 
             n_duplicates += 1
             continue
 
-        if tokenizer.pre_tokenizer is not None:
-            pretokenized_tokens = tokenizer.pre_tokenizer.pre_tokenize_str(token)
+        pre_tokenizer = tokenizer.pre_tokenizer
+        if pre_tokenizer is not None:
+            pretokenized_tokens = pre_tokenizer.pre_tokenize_str(token)
             if len(pretokenized_tokens) != 1:
+                n_multiword += 1
                 continue
+
         seen_tokens.add(token)
         cleaned_vocabulary.append(token)
 

--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -12,11 +12,8 @@ from tokenizers import Tokenizer
 from tokenizers.models import BPE, Unigram
 from transformers import AutoModel, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerFast
 
-from model2vec.distill.inference import (
-    create_output_embeddings_from_model,
-    create_output_embeddings_from_model_and_tokens,
-)
-from model2vec.distill.tokenizer import add_tokens, preprocess_vocabulary, remove_tokens
+from model2vec.distill.inference import create_embeddings
+from model2vec.distill.tokenizer import replace_vocabulary
 from model2vec.distill.utils import select_optimal_device
 from model2vec.model import StaticModel
 
@@ -69,54 +66,54 @@ def distill_from_model(
     :param token_remove_pattern: If this is set to a string, we compile this into a regex. Any tokens that conform to this regex pattern will be removed from the vocabulary.
         If the pattern is so general that it removes all tokens, we throw an error. If the pattern can't be compiled into a valid regex, we also throw an error.
     :return: A StaticModel
+    :raises: ValueError if the regex isn't compileable.
 
     """
-    sif_coefficient = _validate_parameters(tokenizer, vocabulary, apply_zipf, sif_coefficient, use_subword)
+    backend_tokenizer = tokenizer.backend_tokenizer
+    sif_coefficient = _validate_parameters(vocabulary, apply_zipf, sif_coefficient, use_subword)
+
+    if vocabulary is None:
+        vocabulary = []
 
     device = select_optimal_device(device)
     # Make a base list of tokens.
-    tokens: list[str] = []
-    if use_subword:
-        # Create the subword embeddings.
-        tokens, embeddings = create_output_embeddings_from_model(model=model, tokenizer=tokenizer, device=device)
-        new_tokenizer, embeddings = _remove_tokens_and_embeddings(tokenizer, token_remove_pattern, tokens, embeddings)
-    else:
-        # We need to keep the unk token in the tokenizer.
-        unk_token = tokenizer.backend_tokenizer.model.unk_token
-        # Remove all tokens except the UNK token.
-        new_tokenizer = remove_tokens(tokenizer.backend_tokenizer, list(set(tokenizer.get_vocab()) - {unk_token}))
-        # We need to set embeddings to None because we don't know the dimensions of the embeddings yet.
-        embeddings = None
+    subword_vocab: dict[str, int] = tokenizer.get_vocab()
+    subword_tokens: list[str] = [k for k, _ in sorted(subword_vocab.items(), key=lambda x: x[1])]
 
-    if vocabulary:
-        # Preprocess the vocabulary with the original tokenizer.
-        preprocessed_vocabulary = preprocess_vocabulary(tokenizer.backend_tokenizer, vocabulary)
-        n_tokens_before = len(preprocessed_vocabulary)
-        # Clean the vocabulary by removing duplicate tokens and tokens that are in the subword vocabulary.
-        cleaned_vocabulary = _clean_vocabulary(preprocessed_vocabulary, tokens)
-        n_tokens_after = len(cleaned_vocabulary)
-        logger.info(
-            f"Adding {n_tokens_after} tokens to the vocabulary. Removed {n_tokens_before - n_tokens_after} tokens during preprocessing."
-        )
-        # Only create embeddings if we have tokens to add.
-        if cleaned_vocabulary:
-            # Create the embeddings.
-            _, token_embeddings = create_output_embeddings_from_model_and_tokens(
-                model=model,
-                tokenizer=tokenizer,
-                tokens=cleaned_vocabulary,
-                device=device,
-            )
+    n_tokens_before = len(vocabulary)
+    # Clean the vocabulary by removing duplicate tokens and tokens that are in the subword vocabulary.
+    cleaned_vocabulary = _clean_vocabulary(tokenizer.backend_tokenizer, vocabulary, subword_tokens)
+    n_tokens_after = len(cleaned_vocabulary)
+    logger.info(
+        f"Adding {n_tokens_after} tokens to the vocabulary. Removed {n_tokens_before - n_tokens_after} tokens during preprocessing."
+    )
 
-            # If we don't have subword tokens, we still need to create
-            #  some embeddings for [UNK] and some other special tokens.
-            if embeddings is None:
-                embeddings = np.zeros((new_tokenizer.get_vocab_size(), token_embeddings.shape[1]))
-            embeddings = np.concatenate([embeddings, token_embeddings], axis=0)
-            # Add the cleaned vocabulary to the tokenizer.
-            new_tokenizer = add_tokens(new_tokenizer, cleaned_vocabulary)
-        else:
-            logger.warning("Didn't create any token embeddings as all tokens were duplicates or empty.")
+    # Create the embeddings.
+    all_tokens, embeddings = create_embeddings(
+        model=model,
+        tokenizer=tokenizer,
+        tokens=cleaned_vocabulary,
+        device=device,
+        use_subword=use_subword,
+    )
+
+    if token_remove_pattern is not None:
+        try:
+            token_regex = re.compile(token_remove_pattern)
+        except re.error as e:
+            raise ValueError(f"Couldn't compile the regex pattern {token_remove_pattern}.") from e
+        tokens_to_remove = set()
+        indices_to_remove = []
+        for idx, token in enumerate(all_tokens):
+            if token_regex.match(token):
+                tokens_to_remove.add(token)
+                indices_to_remove.append(idx)
+        all_tokens = [token for token in all_tokens if token not in tokens_to_remove]
+        embeddings = np.delete(embeddings, indices_to_remove, axis=0)
+        logger.info(f"Removed {len(tokens_to_remove)} tokens from the tokenizer and embeddings.")
+
+    # Add the cleaned vocabulary to the tokenizer.
+    backend_tokenizer = replace_vocabulary(backend_tokenizer, all_tokens)
 
     # Post process the embeddings by applying PCA and Zipf weighting.
     embeddings = _post_process_embeddings(np.asarray(embeddings), pca_dims, sif_coefficient=sif_coefficient)
@@ -150,7 +147,7 @@ def distill_from_model(
 
     return StaticModel(
         vectors=embeddings,
-        tokenizer=new_tokenizer,
+        tokenizer=backend_tokenizer,
         config=config,
         base_model_name=model_name,
         language=language,
@@ -159,7 +156,6 @@ def distill_from_model(
 
 
 def _validate_parameters(
-    tokenizer: PreTrainedTokenizerFast,
     vocabulary: list[str] | None,
     apply_zipf: bool | None,
     sif_coefficient: float | None,
@@ -168,7 +164,6 @@ def _validate_parameters(
     """
     Validate the parameters passed to the distillation function.
 
-    :param tokenizer: The tokenizer to use.
     :param vocabulary: The vocabulary to use.
     :param apply_zipf: DEPRECATED: This parameter used to control whether Zipf is applied.
         Zipf weighting is now controlled by the sif_coefficient parameter. If this is set to None, no weighting is applied.
@@ -204,49 +199,7 @@ def _validate_parameters(
             "You must pass a vocabulary if you don't use subword tokens. Either pass a vocabulary, or set use_subword to True."
         )
 
-    if vocabulary and isinstance(tokenizer.backend_tokenizer.model, (BPE, Unigram)):
-        raise ValueError(
-            "You passed a vocabulary, but the model you are using does not use a WordPiece tokenizer. "
-            "This is not supported yet."
-            "Feel free to open an issue if this is a blocker: https://github.com/MinishLab/model2vec/issues"
-        )
-
     return sif_coefficient
-
-
-def _remove_tokens_and_embeddings(
-    tokenizer: PreTrainedTokenizerFast, token_remove_pattern: str | None, tokens: list[str], embeddings: np.ndarray
-) -> tuple[Tokenizer, np.ndarray]:
-    if not token_remove_pattern:
-        return tokenizer.backend_tokenizer, embeddings
-
-    try:
-        token_regex = re.compile(token_remove_pattern)
-    except re.error as e:
-        raise ValueError(f"Invalid regex pattern: {token_remove_pattern}") from e
-        # Remove any unused tokens from the tokenizer and embeddings.
-    wrong_tokens = [x for x in tokens if token_regex.match(x)]
-    vocab = tokenizer.get_vocab()
-    # Get the ids of the unused token.
-    wrong_token_ids = [vocab[token] for token in wrong_tokens]
-
-    if len(wrong_token_ids) == len(vocab):
-        raise ValueError(
-            "All tokens in the vocabulary are unused tokens. This will result in an empty tokenizer. "
-            "Please provide a valid token removal pattern. The pattern is now: {token_remove_pattern}"
-        )
-
-        # Remove the unused tokens from the tokenizer.
-    new_tokenizer = remove_tokens(tokenizer.backend_tokenizer, wrong_tokens)
-    if new_tokenizer.get_vocab_size() == tokenizer.backend_tokenizer.get_vocab_size():
-        # This happens if we didn't remove any tokens.
-        return new_tokenizer, embeddings
-
-    # Remove the embeddings of the unused tokens.
-    embeddings = np.delete(embeddings, wrong_token_ids, axis=0)
-    logger.info(f"Removed {len(wrong_tokens)} unused tokens from the tokenizer and embeddings.")
-
-    return new_tokenizer, embeddings
 
 
 def distill(
@@ -345,20 +298,29 @@ def _post_process_embeddings(
     return embeddings
 
 
-def _clean_vocabulary(preprocessed_vocabulary: list[str], added_tokens: list[str]) -> list[str]:
+def _clean_vocabulary(tokenizer: Tokenizer, preprocessed_vocabulary: list[str], added_tokens: list[str]) -> list[str]:
     """Cleans a vocabulary by removing duplicates and tokens that were already in the vocabulary."""
     added_tokens_set = set(added_tokens)
     seen_tokens = set()
     cleaned_vocabulary = []
     n_empty = 0
     n_duplicates = 0
+    n_multiword = 0
     for token in preprocessed_vocabulary:
+        if tokenizer.normalizer is not None:
+            token = tokenizer.normalizer.normalize_str(token)
+
         if not token:
             n_empty += 1
             continue
         if token in seen_tokens or token in added_tokens_set:
             n_duplicates += 1
             continue
+
+        if tokenizer.pre_tokenizer is not None:
+            pretokenized_tokens = tokenizer.pre_tokenizer.pre_tokenize_str(token)
+            if len(pretokenized_tokens) != 1:
+                continue
         seen_tokens.add(token)
         cleaned_vocabulary.append(token)
 
@@ -366,5 +328,7 @@ def _clean_vocabulary(preprocessed_vocabulary: list[str], added_tokens: list[str
         logger.warning(f"Removed {n_duplicates} duplicate tokens.")
     if n_empty:
         logger.warning(f"Removed {n_empty} empty tokens.")
+    if n_multiword:
+        logger.warning(f"Removed {n_multiword} multiword tokens.")
 
     return cleaned_vocabulary

--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -98,8 +98,10 @@ def distill_from_model(
         token_remove_regex=token_remove_regex,
     )
 
+    unk_token = tokenizer.special_tokens_map.get("unk_token")
+    pad_token = tokenizer.special_tokens_map.get("pad_token")
     # Add the cleaned vocabulary to the tokenizer.
-    backend_tokenizer = replace_vocabulary(backend_tokenizer, all_tokens)
+    backend_tokenizer = replace_vocabulary(backend_tokenizer, all_tokens, unk_token=unk_token, pad_token=pad_token)
 
     # Post process the embeddings by applying PCA and Zipf weighting.
     embeddings = _post_process_embeddings(np.asarray(embeddings), pca_dims, sif_coefficient=sif_coefficient)

--- a/model2vec/distill/inference.py
+++ b/model2vec/distill/inference.py
@@ -56,7 +56,7 @@ def create_embeddings(
     out_weights: np.ndarray
     intermediate_weights: list[np.ndarray] = []
 
-    pad_token = 0
+    pad_token = tokenizer.pad_token_type_id
 
     out_tokens = []
     tokenized: list[torch.Tensor] = []

--- a/model2vec/distill/inference.py
+++ b/model2vec/distill/inference.py
@@ -8,9 +8,12 @@ from typing import Protocol, Union
 
 import numpy as np
 import torch
+from torch.nn.utils.rnn import pad_sequence
 from tqdm import tqdm
-from transformers import PreTrainedModel, PreTrainedTokenizer
+from transformers import PreTrainedModel, PreTrainedTokenizerFast
 from transformers.modeling_outputs import BaseModelOutputWithPoolingAndCrossAttentions
+
+from model2vec.distill.tokenizer import _get_unk_token
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +27,10 @@ class ModulewithWeights(Protocol):
     weight: torch.nn.Parameter
 
 
-def create_output_embeddings_from_model_and_tokens(
+def create_embeddings(
     model: PreTrainedModel,
-    tokenizer: PreTrainedTokenizer,
+    tokenizer: PreTrainedTokenizerFast,
+    use_subword: bool,
     tokens: list[str],
     device: str,
 ) -> tuple[list[str], np.ndarray]:
@@ -38,6 +42,7 @@ def create_output_embeddings_from_model_and_tokens(
     :param model: The model to use.
         This should be a transformers model.
     :param tokenizer: The tokenizer to use.
+    :param use_subword: Whether to include subword tokens in the output.
     :param tokens: The tokens to use.
     :param device: The torch device to use.
     :return: The tokens and output embeddings.
@@ -47,17 +52,53 @@ def create_output_embeddings_from_model_and_tokens(
     out_weights: np.ndarray
     intermediate_weights: list[np.ndarray] = []
 
-    for batch_idx in tqdm(range(0, len(tokens), _DEFAULT_BATCH_SIZE)):
-        batch = tokens[batch_idx : batch_idx + _DEFAULT_BATCH_SIZE]
-        out = _encode_mean_using_model(model, tokenizer, batch)
+    pad_token = 0
+
+    out_tokens = []
+    tokenized: list[torch.Tensor] = []
+
+    if use_subword:
+        ids = torch.arange(len(tokenizer.get_vocab()))
+    elif unk_token := _get_unk_token(tokenizer.backend_tokenizer):
+        # Include UNK token
+        ids = torch.Tensor(tokenizer.convert_tokens_to_ids([unk_token])).long()
+    else:
+        ids = None
+
+    if ids is not None:
+        dummy_encoding = tokenizer.encode("A")
+        bos_token_id, eos_token_id = dummy_encoding[0], dummy_encoding[-1]
+
+        bos = torch.full([len(ids)], fill_value=bos_token_id)
+        eos = torch.full([len(ids)], fill_value=eos_token_id)
+
+        tokenized.extend(torch.stack([bos, ids, eos], dim=1))
+        out_tokens.extend(tokenizer.convert_ids_to_tokens(ids))
+
+    tokenized.extend([tokenizer.encode_plus(token, return_tensors="pt")["input_ids"][0] for token in tokens])
+
+    for batch_idx in tqdm(range(0, len(tokenized), _DEFAULT_BATCH_SIZE)):
+        batch = tokenized[batch_idx : batch_idx + _DEFAULT_BATCH_SIZE]
+
+        encoded = {}
+        encoded["input_ids"] = pad_sequence(batch, batch_first=True, padding_value=pad_token)
+        encoded["attention_mask"] = encoded["input_ids"] != pad_token
+
+        # Add token_type_ids only if the model supports it
+        if "token_type_ids" in inspect.getfullargspec(model.forward).args:
+            encoded["token_type_ids"] = torch.zeros_like(encoded["input_ids"])
+
+        out = _encode_mean_using_model(model, encoded)
         intermediate_weights.append(out.numpy())
+
+    out_tokens.extend(tokens)
     out_weights = np.concatenate(intermediate_weights)
 
-    return tokens, out_weights
+    return out_tokens, out_weights
 
 
 @torch.no_grad()
-def _encode_mean_using_model(model: PreTrainedModel, tokenizer: PreTrainedTokenizer, tokens: list[str]) -> torch.Tensor:
+def _encode_mean_using_model(model: PreTrainedModel, encodings: dict[str, torch.Tensor]) -> torch.Tensor:
     """
     Encode a batch of tokens using a model.
 
@@ -65,11 +106,10 @@ def _encode_mean_using_model(model: PreTrainedModel, tokenizer: PreTrainedTokeni
     So detection of these is necessary.
 
     :param model: The model to use.
-    :param tokenizer: The tokenizer to use.
-    :param tokens: The tokens to encode.
+    :param encodings: The encoded tokens to turn into features.
     :return: The mean of the output for each token.
     """
-    encodings = tokenizer(tokens, return_tensors="pt", padding=True, truncation=True).to(model.device)
+    encodings = {k: v.to(model.device) for k, v in encodings.items()}
     encoded: BaseModelOutputWithPoolingAndCrossAttentions = model(**encodings)
     out: torch.Tensor = encoded.last_hidden_state.cpu()
     # NOTE: If the dtype is bfloat 16, we convert to float32,
@@ -78,90 +118,10 @@ def _encode_mean_using_model(model: PreTrainedModel, tokenizer: PreTrainedTokeni
     if out.dtype == torch.bfloat16:
         out = out.float()
 
-    mask = encodings["attention_mask"].cpu()
-    # NOTE: evil hack. For any batch, there will be a mask vector
-    # which has all 1s, because we pad to max_length. argmin returns 0
-    # in this case, which is wrong. But because we end up subtracting 1
-    # from it, we use -1, which is correct.
-    last_nonzero_index = mask.argmin(1) - 1
-    # NOTE: do not change the order of these calls. If you do, the hack
-    # above will no longer be evil (it will turn good), and will no longer work.
-    mask[torch.arange(mask.shape[0]), last_nonzero_index] = 0
-    mask[:, 0] = 0
+    # Take the mean by averaging over the attention mask.
+    mask = encodings["attention_mask"].cpu().float()
+    mask /= mask.sum(1)[:, None]
 
-    # We take the mean of embeddings by first summing
     result = torch.bmm(mask[:, None, :].float(), out).squeeze(1)
 
-    # Divide by the number of non-padding tokens, non-cls, etc. tokens.
-    divisor = mask.sum(1)
-    # Account for the case where divisor is 0.
-    divisor[divisor == 0] = 1
-
-    return result / divisor[:, None]
-
-
-def create_output_embeddings_from_model(
-    model: PreTrainedModel,
-    tokenizer: PreTrainedTokenizer,
-    device: str,
-) -> tuple[list[str], np.ndarray]:
-    """
-    Create output embeddings for a bunch of tokens using a pretrained model.
-
-    It does a forward pass for all tokens passed in the tokenizer vocabulary.
-
-    :param model: The model to use.
-        This should be a transformers model.
-    :param tokenizer: The tokenizer to use.
-    :param device: The torch device to use.
-    :return: The tokens and output embeddings.
-    """
-    model = model.to(device)
-
-    # Quick check to see if the tokenizer is consistent.
-    vocab_length = len(tokenizer.get_vocab())
-    if vocab_length != tokenizer.vocab_size:
-        logger.warning(
-            f"Reported vocab size {tokenizer.vocab_size} is inconsistent with the vocab size {vocab_length}."
-        )
-
-    ids = torch.arange(vocab_length)
-
-    # Work-around to get the eos and bos token ids without having to go into tokenizer internals.
-    dummy_encoding = tokenizer.encode("A")
-    bos_token_id, eos_token_id = dummy_encoding[0], dummy_encoding[-1]
-
-    bos = torch.full([len(ids)], fill_value=bos_token_id)
-    eos = torch.full([len(ids)], fill_value=eos_token_id)
-
-    # NOTE: reversing the bos and eos tokens works better on our benchmarks.
-    stacked = torch.stack([eos, ids, bos], dim=1)
-
-    intermediate_weights: list[np.ndarray] = []
-    for batch_idx in tqdm(range(0, len(stacked), _DEFAULT_BATCH_SIZE)):
-        batch = stacked[batch_idx : batch_idx + _DEFAULT_BATCH_SIZE].to(model.device)
-        with torch.no_grad():
-            attention_mask = torch.ones_like(batch)
-            # Prepare model inputs
-            model_inputs = {"input_ids": batch.to(device), "attention_mask": attention_mask}
-
-            # Add token_type_ids only if the model supports it
-            if "token_type_ids" in inspect.getfullargspec(model.forward).args:
-                model_inputs["token_type_ids"] = torch.zeros_like(batch)
-
-            # Perform the forward pass
-            encoded_output: BaseModelOutputWithPoolingAndCrossAttentions = model(**model_inputs)
-            out: torch.Tensor = encoded_output.last_hidden_state
-            # NOTE: If the dtype is bfloat 16, we convert to float32,
-            # because numpy does not suport bfloat16
-            # See here: https://github.com/numpy/numpy/issues/19808
-            if out.dtype == torch.bfloat16:
-                out = out.float()
-
-        # Add the output to the intermediate weights
-        intermediate_weights.append(out.mean(1).detach().cpu().numpy())
-
-    # Concatenate the intermediate weights
-    out_weights = np.concatenate(intermediate_weights)
-
-    return tokenizer.convert_ids_to_tokens(ids), out_weights
+    return result

--- a/model2vec/distill/tokenizer.py
+++ b/model2vec/distill/tokenizer.py
@@ -71,15 +71,15 @@ def _make_new_merges_from_vocab(
     merges: list[tuple[str, str]], tokens: list[str], special_tokens: set[str | None]
 ) -> list[tuple[str, str]]:
     """
-    Generate new merges (bigrams) from a vocabulary.
+    Generate new merges from a vocabulary.
 
-    This function creates new merge pairs (bigrams) from a given vocabulary of tokens.
+    This function creates new merge pairs from a given vocabulary of tokens.
     The merges are used to build or extend a tokenizer's merge table.
 
-    :param merges: The list of existing merges in the form "first second" where first and second are tokens.
+    :param merges: The list of existing merges in the form (first, second) where first and second are tokens.
     :param tokens: The list of tokens (vocabulary) from which to generate new merges.
-    :param special_tokens: Tokens that are not merged.
-    :return: The list of new merges in the form "first second" where first and second are tokens.
+    :param special_tokens: Tokens that should not be merged.
+    :return: The list of new merges in the form (first, second) where first and second are tokens.
     """
     new_merges = merges.copy()
     current_vocab = set(tokens) - special_tokens
@@ -93,8 +93,8 @@ def _make_new_merges_from_vocab(
         if len(token) == 1:
             continue
         merges = []
-        for needle in range(1, len(token)):
-            first, second = token[:needle], token[needle:]
+        for index in range(1, len(token)):
+            first, second = token[:index], token[index:]
             if first in current_vocab and second in current_vocab:
                 merges.append((first, second))
         if not merges:

--- a/model2vec/distill/tokenizer.py
+++ b/model2vec/distill/tokenizer.py
@@ -23,14 +23,12 @@ def get_unk_token(tokenizer: Tokenizer) -> str | None:
     if isinstance(model, WordPiece):
         return model.unk_token
     elif isinstance(model, BPE):
-        return None
+        return model.unk_token
     elif isinstance(model, Unigram):
         unk_id: int | None = model.unk_id
         if unk_id is None:
             return None
-        vocab = tokenizer.get_vocab()
-        vocab_sorted = sorted(vocab.items(), key=lambda x: x[1])
-        return vocab_sorted[unk_id]
+        return tokenizer.id_to_token(unk_id)
     else:
         logger.warning(f"Unknown model type {type(model)}")
         return None

--- a/model2vec/distill/utils.py
+++ b/model2vec/distill/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from logging import getLogger
 
 import torch
@@ -26,3 +27,23 @@ def select_optimal_device(device: str | None) -> str:
         logger.info(f"Automatically selected device: {device}")
 
     return device
+
+
+def filter_vocabulary_by_regex(token_remove_regex: re.Pattern, tokens: list[tuple[str, int]]) -> list[int]:
+    """
+    Filter a sorted vocabulary by a regex pattern and return their ids.
+
+    :param token_remove_regex: The regex pattern to filter by.
+    :param tokens: The tokens to filter. This should be a list of tuples with the token and its id.
+    :return: The ids of the tokens left after filtering.
+    :raises ValueError: If no tokens are left after filtering.
+    """
+    id_list = []
+    for token, id in tokens:
+        if not token_remove_regex.match(token):
+            id_list.append(id)
+
+    if not id_list:
+        raise ValueError("No tokens left after filtering by regex.")
+
+    return id_list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import torch
 from tokenizers import Tokenizer
-from tokenizers.models import WordLevel
+from tokenizers.models import WordPiece
 from tokenizers.pre_tokenizers import Whitespace
 from transformers import AutoModel, AutoTokenizer
 
@@ -20,7 +20,7 @@ def mock_tokenizer() -> Tokenizer:
     vocab = ["[PAD]", "word1", "word2", "word3", "[UNK]"]
     unk_token = "[UNK]"
 
-    model = WordLevel(vocab={word: idx for idx, word in enumerate(vocab)}, unk_token=unk_token)
+    model = WordPiece(vocab={word: idx for idx, word in enumerate(vocab)}, unk_token=unk_token)
     tokenizer = Tokenizer(model)
     tokenizer.pre_tokenizer = Whitespace()
 

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -82,6 +82,7 @@ def test_distill_from_model(
             pca_dims=pca_dims,
             apply_zipf=apply_zipf,
             use_subword=use_subword,
+            token_remove_pattern=None,
         )
 
         static_model2 = distill(
@@ -91,6 +92,7 @@ def test_distill_from_model(
             pca_dims=pca_dims,
             apply_zipf=apply_zipf,
             use_subword=use_subword,
+            token_remove_pattern=None,
         )
 
         assert static_model.embedding.shape == static_model2.embedding.shape

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ wheels = [
 
 [[package]]
 name = "model2vec"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
This PR completely rewrites the distill backend.

* There's no longer a difference between subword and vocabulary inference
* BPE and unigram tokenizer token removal/addition is supported
* All tokenizers now take into account normalization when adding tokens
* Tokens that are multi-word units are no longer allowed
* Make tokenizers a bit smaller by removing unneeded special tokens