### PR TITLE
feat: track token provenance

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -13,7 +13,7 @@ from transformers import AutoModel, AutoTokenizer, PreTrainedModel, PreTrainedTo
 
 from model2vec.distill.inference import create_embeddings
 from model2vec.distill.tokenizer import replace_vocabulary
-from model2vec.distill.utils import select_optimal_device
+from model2vec.distill.utils import Token, select_optimal_device
 from model2vec.model import StaticModel
 from model2vec.quantization import DType, quantize_embeddings
 

--- a/model2vec/distill/tokenizer.py
+++ b/model2vec/distill/tokenizer.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from tokenizers import Tokenizer
 
+from model2vec.distill.utils import Token
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +19,7 @@ _DEFAULT_POST_PROCESSOR_TEMPLATE = {
 }
 
 
-def _pre_tokenize_vocabulary(tokenizer: Tokenizer, tokens: list[str]) -> list[str]:
+def _pre_tokenize_vocabulary(tokenizer: Tokenizer, tokens: list[Token]) -> list[str]:
     """
     Apply pre-tokenization to vocabulary tokens if a pre-tokenizer is present.
 
@@ -33,14 +35,14 @@ def _pre_tokenize_vocabulary(tokenizer: Tokenizer, tokens: list[str]) -> list[st
 
     if tokenizer.pre_tokenizer is not None:
         for token in tokens:
-            if token in current_tokenizer_vocab:
-                pre_tokenized_tokens.append(token)
+            if token.is_subword:
+                pre_tokenized_tokens.append(token.form)
             else:
                 # We know 100% sure that all pretokenized tokens will have length 1.
-                pretokenized_tokens, _ = zip(*tokenizer.pre_tokenizer.pre_tokenize_str(f" {token}"))
+                pretokenized_tokens, _ = zip(*tokenizer.pre_tokenizer.pre_tokenize_str(f" {token.form}"))
                 pre_tokenized_tokens.append(pretokenized_tokens[-1])
     else:
-        pre_tokenized_tokens = tokens
+        pre_tokenized_tokens = [token.form for token in tokens]
 
     return pre_tokenized_tokens
 
@@ -106,7 +108,7 @@ def _make_new_merges_from_vocab(
 
 
 def replace_vocabulary(
-    tokenizer: Tokenizer, new_vocabulary: list[str], unk_token: str | None, pad_token: str | None
+    tokenizer: Tokenizer, new_vocabulary: list[Token], unk_token: str | None, pad_token: str | None
 ) -> Tokenizer:
     """Replace the vocabulary of a tokenizer with a new one."""
     tokenizer_json: dict[str, Any] = json.loads(tokenizer.to_str())
@@ -139,8 +141,8 @@ def replace_vocabulary(
         vocab = tokenizer_json["model"]["vocab"]
         unk_token = vocab[unk_id][0] if unk_id is not None else None
         current_probas = dict(tokenizer_json["model"]["vocab"])
-        lowest_proba = min(current_probas.values())
-        new_probas = {word: current_probas.get(word, lowest_proba) for word in pre_tokenized_tokens}
+        avg_proba = sum(current_probas.values()) / len(current_probas)
+        new_probas = {word: current_probas.get(word, avg_proba) for word in pre_tokenized_tokens}
         tokenizer_json["model"]["vocab"] = sorted(new_probas.items(), key=lambda x: x[1], reverse=True)
 
         tokens, _ = zip(*tokenizer_json["model"]["vocab"])

--- a/model2vec/distill/utils.py
+++ b/model2vec/distill/utils.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from logging import getLogger
 
 import torch
 
 logger = getLogger(__name__)
+
+
+@dataclass
+class Token:
+    """A class to represent a token."""
+
+    form: str
+    is_subword: bool
 
 
 def select_optimal_device(device: str | None) -> str:


### PR DESCRIPTION
Fixes #209 (again 😓 )

This PR adds a `Token` class to keep track of whether a token was originally a subword or added token. If it was a subword token, we should not pretokenize it. Previously, we relied on whether a token was in the original vocabulary, but this turned out to not work for unigram tokenizers with a metaspace if the token was also a subword token.

For "ELLE", for example: 

1. Check if "ELLE" is in vocab, we pretokenize it to "_ELLE". This is fine
2. Then, when adding it, we need to check whether it is a subword. But "ELLE" is also a subword.
3. So we don't pretokenize it before adding it, causing us to add two tokens with the same surface form.