### PR TITLE
fix: issues with unk and pad

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -66,7 +66,7 @@ def distill_from_model(
     :param token_remove_pattern: If this is set to a string, we compile this into a regex. Any tokens that conform to this regex pattern will be removed from the vocabulary.
         If the pattern is so general that it removes all tokens, we throw an error. If the pattern can't be compiled into a valid regex, we also throw an error.
     :param quantize_to: The data type to quantize to. Can be any of the DType enum members or their string equivalents.
-    :param use_subword: Deprecated. If this is not set to None, we show a warning. It doesn't do anything.
+    :param use_subword: DEPRECATED: If this is not set to None, we show a warning. It doesn't do anything.
     :return: A StaticModel
 
     """
@@ -229,7 +229,7 @@ def distill(
     :param token_remove_pattern: If this is set to a string, we compile this into a regex. Any tokens that conform to this regex pattern will be removed from the vocabulary.
     :param trust_remote_code: Whether to trust the remote code. If this is False, we will only load components coming from `transformers`. If this is True, we will load all components.
     :param quantize_to: The data type to quantize to. Can be any of the DType enum members or their string equivalents.
-    :param use_subword: Deprecated. If this is not set to None, we show a warning. It doesn't do anything.
+    :param use_subword: DEPRECATED: If this is not set to None, we show a warning. It doesn't do anything.
     :return: A StaticModel
 
     """

--- a/model2vec/distill/inference.py
+++ b/model2vec/distill/inference.py
@@ -56,10 +56,12 @@ def create_embeddings(
     out_tokens: list[Token] = []
     tokenized: list[torch.Tensor] = []
     pad_token = tokenizer.special_tokens_map.get("pad_token")
+    # We need to use the pad token id for padding below.
     pad_token_id = tokenizer.convert_tokens_to_ids(pad_token)
     unk_token = tokenizer.special_tokens_map.get("unk_token")
 
-    tokens_to_keep = {pad_token, unk_token}
+    # Empty set if no pad or unk token is set.
+    tokens_to_keep = {pad_token, unk_token} - {None}
 
     if token_remove_regex is not None:
         # Sort the vocabulary by id, important for zipf.

--- a/model2vec/distill/tokenizer.py
+++ b/model2vec/distill/tokenizer.py
@@ -133,7 +133,7 @@ def replace_vocabulary(
     if model_type in {"WordPiece", "BPE"}:
         # Easiest, just add the new vocab
         unk_token = unk_token or tokenizer_json["model"]["unk_token"]
-        tokenizer_json["model"]["unk_token"] = "[UNK]"
+        tokenizer_json["model"]["unk_token"] = "[UNK]" if unk_token else None
         tokenizer_json["model"]["vocab"] = {token: idx for idx, token in enumerate(pre_tokenized_tokens)}
 
         if model_type == "BPE":

--- a/model2vec/distill/utils.py
+++ b/model2vec/distill/utils.py
@@ -14,7 +14,7 @@ class Token:
     """A class to represent a token."""
 
     form: str
-    is_subword: bool
+    is_original: bool
 
 
 def select_optimal_device(device: str | None) -> str:


### PR DESCRIPTION
Some tokenizers use `<|endoftext|>` or other tokens as PAD token, this breaks the assumption in `StaticModelForClassification`.

Fixes #223 