### PR TITLE
feat: allow passing validation set explicitly

### DIFF
--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -4,7 +4,7 @@ import logging
 from collections import Counter
 from itertools import chain
 from tempfile import TemporaryDirectory
-from typing import TypeVar, cast, Optional
+from typing import TypeVar, cast
 
 import lightning as pl
 import numpy as np
@@ -135,8 +135,8 @@ class StaticModelForClassification(FinetunableStaticModel):
         early_stopping_patience: int | None = 5,
         test_size: float = 0.1,
         device: str = "auto",
-        X_val: Optional[list[str]] = None,
-        y_val: Optional[list[str]] = None
+        X_val: list[str] | None = None,
+        y_val: LabelType | None = None
     ) -> StaticModelForClassification:
         """
         Fit a model.

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -136,7 +136,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         test_size: float = 0.1,
         device: str = "auto",
         X_val: list[str] | None = None,
-        y_val: LabelType | None = None
+        y_val: LabelType | None = None,
     ) -> StaticModelForClassification:
         """
         Fit a model.
@@ -165,6 +165,7 @@ class StaticModelForClassification(FinetunableStaticModel):
         :param X_val: The texts to be used for validation.
         :param y_val: The labels to be used for validation.
         :return: The fitted model.
+        :raises ValueError: If either X_val or y_val are provided, but not both.
         """
         pl.seed_everything(_RANDOM_SEED)
         logger.info("Re-initializing model.")
@@ -177,6 +178,10 @@ class StaticModelForClassification(FinetunableStaticModel):
             raise ValueError("Both X_val and y_val must be provided together, or neither.")
 
         if X_val is not None and y_val is not None:
+            # Additional check to ensure y_val is of the same type as y
+            if type(y_val[0]) != type(y[0]):
+                raise ValueError("X_val and y_val must be of the same type as X and y.")
+
             train_texts = X
             train_labels = y
             validation_texts = X_val

--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -173,6 +173,9 @@ class StaticModelForClassification(FinetunableStaticModel):
 
         self._initialize(y)
 
+        if (X_val is not None) != (y_val is not None):
+            raise ValueError("Both X_val and y_val must be provided together, or neither.")
+
         if X_val is not None and y_val is not None:
             train_texts = X
             train_labels = y


### PR DESCRIPTION
i have been experimenting with model2vec and it is great! kudos for the awesome work

I wanted to use my own validation set but that was not exposed, this PR simply adds optional arguments to the `fit` method to allow passing your own validation data