### PR TITLE
fix: distillation for models without card

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -128,7 +128,7 @@ def distill_from_model(
         # Get the language from the model card.
         try:
             info = model_info(model_name)
-            language = info.cardData.get("language", None)
+            language = info.cardData.get("language", None) if info.cardData is not None else None
         except Exception as e:
             # NOTE: bare except because there's many reasons this can fail.
             logger.warning(f"Couldn't get the model info from the Hugging Face Hub: {e}. Setting language to None.")


### PR DESCRIPTION
was failing to distill models that didn't include a model card in huggingface

```bash
fdemelo/xlm-roberta-ovos-intent-classifier
Some weights of XLMRobertaModel were not initialized from the model checkpoint at fdemelo/xlm-roberta-ovos-intent-classifier and are newly initialized: ['pooler.dense.bias', 'pooler.dense.weight']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
Encoding tokens: 100%|██████████| 249999/249999 [03:34<00:00, 1165.90 tokens/s]
Traceback (most recent call last):
  File "/home/miro/PycharmProjects/NLP/distilintent/distill.py", line 124, in <module>
    m2v_model = distill(model_name=m, pca_dims=256)
  File "/home/miro/PycharmProjects/model2vec/model2vec/distill/distillation.py", line 239, in distill
    return distill_from_model(
        model=model,
    ...<8 lines>...
        use_subword=use_subword,
    )
  File "/home/miro/PycharmProjects/model2vec/model2vec/distill/distillation.py", line 139, in distill_from_model
    language = info.cardData.get("language", None)
               ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```