### PR TITLE
Remove first singular projection from embeddings (most frequent discourse correction)

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -29,6 +29,7 @@ def distill_from_model(
     token_remove_pattern: str | None = r"\[unused\d+\]",
     quantize_to: DType | str = DType.Float16,
     use_subword: bool | None = None,
+    remove_bias: bool = False,
 ) -> StaticModel:
     """
     Distill a staticmodel from a sentence transformer.
@@ -114,7 +115,12 @@ def distill_from_model(
     )
 
     # Post process the embeddings by applying PCA and Zipf weighting.
-    embeddings = post_process_embeddings(np.asarray(embeddings), pca_dims, sif_coefficient=sif_coefficient)
+    embeddings = post_process_embeddings(
+        np.asarray(embeddings),
+        pca_dims,
+        sif_coefficient=sif_coefficient,
+        remove_bias=remove_bias,
+    )
     # Quantize the embeddings.
     embeddings = quantize_embeddings(embeddings, quantize_to)
 
@@ -211,6 +217,7 @@ def distill(
     trust_remote_code: bool = False,
     quantize_to: DType | str = DType.Float16,
     use_subword: bool | None = None,
+    remove_bias: bool = False,
 ) -> StaticModel:
     """
     Distill a staticmodel from a sentence transformer.
@@ -255,4 +262,5 @@ def distill(
         sif_coefficient=sif_coefficient,
         quantize_to=quantize_to,
         use_subword=use_subword,
+        remove_bias=remove_bias,
     )

--- a/model2vec/distill/inference.py
+++ b/model2vec/distill/inference.py
@@ -118,7 +118,7 @@ def post_process_embeddings(
     embeddings: np.ndarray,
     pca_dims: PCADimType,
     sif_coefficient: float | None = 1e-4,
-    remove_bias: bool = True,
+    remove_bias: bool = False,
 ) -> np.ndarray:
     """Post process embeddings by applying PCA and SIF weighting by estimating the frequencies through Zipf's law."""
     if pca_dims is not None or remove_bias:


### PR DESCRIPTION
Upon distilling models, for each token embeddings vector, this PR proposes to remove its first principal component, that is, its component along the first singular vector of the PCA decomposition.
The principle underpinning this step is proposed in the paper:

> Arora, Liang & Ma, "A Simple but Tough-to-Beat Baseline for Sentence Embeddings," International Conference on Learning Representations (ICLR), 2017 (https://openreview.net/forum?id=SyK00v5xx).

The paper argues that the first singular component accrues most of the underlying common spectral content among tokens related to the so-called "most frequent discourse", i.e., the mutual information among words in very frequent expressions or syntax-related context. Ultimately, the correction should render the embeddings more discriminative for downstream tasks.