### PR TITLE
chore: Added python 3.13 to pyproject and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       # Run tests with coverage
       - name: Run tests under coverage
         run: |
-          coverage run -m pytest
+          coverage run --source=model2vec -m pytest
           coverage report
 
       # Upload results to Codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
             python-version: "3.11"
           - os: windows-latest
             python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.13"
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: windows-latest
             python-version: "3.9"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ install:
 
 install-no-pre-commit:
 	uv pip install ".[dev,distill,inference,train]"
-	uv pip install "torch<2.5.0"
 
 install-base:
 	uv sync --extra dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
 ]
 


### PR DESCRIPTION
This PR adds Python 3.13 to our pyproject supported languages and to CI. Many of our downloads come from 3.13 now but we don't "officially" test/support it right now.