### PR TITLE
fix: F rule, A rule, update ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: pydoclint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.13.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/model2vec/model.py
+++ b/model2vec/model.py
@@ -5,7 +5,7 @@ import os
 from logging import getLogger
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Iterator, Sequence, Union, cast, overload
+from typing import Any, Iterator, Sequence, Union, overload
 
 import numpy as np
 from joblib import delayed
@@ -493,8 +493,6 @@ def quantize_model(
     :return: A new StaticModel with the quantized embeddings.
     :raises: ValueError if the model is already quantized.
     """
-    from model2vec.quantization import quantize_and_reduce_dim
-
     token_mapping: np.ndarray | None
     weights: np.ndarray | None
     if vocabulary_quantization is not None:

--- a/model2vec/utils.py
+++ b/model2vec/utils.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import json
 import logging
 import re
 from importlib import import_module
 from importlib.metadata import metadata
-from pathlib import Path
-from typing import Any, Iterator, Protocol, cast
+from typing import Any, Iterator, Protocol
 
 import numpy as np
-import safetensors
 from joblib import Parallel
-from tokenizers import Tokenizer
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)

--- a/model2vec/vocabulary_quantization.py
+++ b/model2vec/vocabulary_quantization.py
@@ -10,8 +10,7 @@ try:
     from sklearn.cluster import KMeans
 except ImportError:
     raise ImportError(
-        "scikit-learn is required for quantizing the vocabulary. "
-        "Please install model2vec with the quantization extra."
+        "scikit-learn is required for quantizing the vocabulary. Please install model2vec with the quantization extra."
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ select = [
     "C90",
     # Pydocstyle: Enforce docstrings
     "D",
+    # Remove unused imports
+    "F",
     # Isort: Enforce import order
     "I",
     # Numpy: Enforce numpy style
@@ -96,7 +98,7 @@ select = [
 
 ignore = [
     # Allow self and cls to be untyped, and allow Any type
-    "ANN101", "ANN102", "ANN401",
+    "ANN001", "ANN002", "ANN401",
     # Pydocstyle ignores
     "D100", "D101", "D104", "D203", "D212", "D401",
     # Allow use of f-strings in logging


### PR DESCRIPTION
This PR:

adds the F rule
replaces deprecated A rules with new ones
updates ruff to use the new rules