### PR TITLE
fix: Disable MPS for Torch versions >=2.8.0

### DIFF
--- a/model2vec/distill/utils.py
+++ b/model2vec/distill/utils.py
@@ -26,7 +26,7 @@ def select_optimal_device(device: str | None) -> str:
         if device == "mps" and mps_broken:
             raise RuntimeError(
                 f"MPS is disabled for PyTorch {torch.__version__} due to known performance regressions. "
-                "Please use CPU or CUDA instead."
+                "Please use CPU or CUDA instead, or use a PyTorch version < 2.8.0."
             )
         else:
             return device
@@ -37,7 +37,7 @@ def select_optimal_device(device: str | None) -> str:
         if mps_broken:
             logger.warning(
                 f"MPS is available but PyTorch {torch.__version__} has known performance regressions. "
-                "Falling back to CPU."
+                "Falling back to CPU. Please use a PyTorch version < 2.8.0 to enable MPS support."
             )
             device = "cpu"
         else:

--- a/model2vec/distill/utils.py
+++ b/model2vec/distill/utils.py
@@ -3,26 +3,47 @@ from __future__ import annotations
 from logging import getLogger
 
 import torch
+from packaging import version
 
 logger = getLogger(__name__)
 
 
 def select_optimal_device(device: str | None) -> str:
     """
-    Guess what your optimal device should be based on backend availability.
+    Get the optimal device to use based on backend availability.
 
-    If you pass a device, we just pass it through.
+    For Torch versions >= 2.8.0, MPS is disabled due to known performance regressions.
 
-    :param device: The device to use. If this is not None you get back what you passed.
+    :param device: The device to use. If this is None, the device is automatically selected.
     :return: The selected device.
+    :raises RuntimeError: If MPS is requested on a PyTorch version where it is disabled.
     """
-    if device is None:
-        if torch.cuda.is_available():
-            device = "cuda"
-        elif torch.backends.mps.is_available():
-            device = "mps"
-        else:
-            device = "cpu"
-        logger.info(f"Automatically selected device: {device}")
+    # Get the torch version and check if MPS is broken
+    torch_version = version.parse(torch.__version__.split("+")[0])
+    mps_broken = torch_version >= version.parse("2.8.0")
 
+    if device:
+        if device == "mps" and mps_broken:
+            raise RuntimeError(
+                f"MPS is disabled for PyTorch {torch.__version__} due to known performance regressions. "
+                "Please use CPU or CUDA instead."
+            )
+        else:
+            return device
+
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        if mps_broken:
+            logger.warning(
+                f"MPS is available but PyTorch {torch.__version__} has known performance regressions. "
+                "Falling back to CPU."
+            )
+            device = "cpu"
+        else:
+            device = "mps"
+    else:
+        device = "cpu"
+
+    logger.info(f"Automatically selected device: {device}")
     return device


### PR DESCRIPTION
Torch shows significant drops in performance across tasks when distilling with MPS on version 2.8.0. For this reason, it's disabled until this has been resolved in Torch.