### PR TITLE
fix: if layers == 0, layers were not initialized

### DIFF
--- a/model2vec/train/classifier.py
+++ b/model2vec/train/classifier.py
@@ -84,9 +84,8 @@ class StaticModelForClassification(FinetunableStaticModel):
         if linear_modules:
             *initial, last = linear_modules
             for module in initial:
-                if isinstance(module, nn.Linear):
-                    nn.init.kaiming_uniform_(module.weight, nonlinearity="relu")
-                    nn.init.zeros_(module.bias)
+                nn.init.kaiming_uniform_(module.weight, nonlinearity="relu")
+                nn.init.zeros_(module.bias)
             # Final layer does not kaiming
             nn.init.xavier_uniform_(last.weight)
             nn.init.zeros_(last.bias)


### PR DESCRIPTION
While working on a classifier with no hidden layers, I saw that linear layers were not initialized properly if n_layers == 0. The short circuiting was returning a linear with default initialization, which happens to be kaiming anyway.

Not a big deal, but just for consistency. I also initialized to xavier_uniform for the final layer, because this could help (that is, kaiming init is often used for relu, xavier for linear or tanh), although I didn't see any difference on 20 newsgroups. 