### PR TITLE
fix: upgrade skeletoken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "ruff",
 ]
 
-distill = ["torch", "transformers<5.4.0", "scikit-learn", "skeletoken>=0.3.2"]
+distill = ["torch", "transformers<5.4.0", "scikit-learn", "skeletoken>=0.3.3"]
 onnx = ["onnx", "torch"]
 # train also installs inference
 train = ["torch", "lightning", "scikit-learn", "skops"]


### PR DESCRIPTION
In skeletoken version 0.3.2, I didn't remap added tokens if they were new. This caused a mismatch for the modernbert tokenizer, but only when multiwords were added. So, once we re-added multiword support in #317, this bug appeared. This only affects the modernbert tokenizer when using multiword tokens.

