### PR TITLE
fix: don't set weights for non-quantized models

### DIFF
--- a/model2vec/distill/distillation.py
+++ b/model2vec/distill/distillation.py
@@ -118,6 +118,8 @@ def distill_from_model(
     else:
         # Post-process the embeddings.
         embeddings, weights = post_process_embeddings(np.asarray(embeddings), pca_dims, sif_coefficient=sif_coefficient)
+        embeddings = embeddings * weights[:, None]
+        weights = None
         token_mapping = None
     # Quantize the embeddings.
     embeddings = quantize_embeddings(embeddings, quantize_to)


### PR DESCRIPTION
In the current version of model2vec, we set the weights parameter to the zipf weights we create during distillation. However, this has the unfortunate consequence of leading to different results for sentence transformers and model2vec itself. Sentence transformers does not read the weights vector, and does not apply it. This has a small negative effect on performance on models that are directly used in sentence-transformers.