### PR TITLE
fix: guard against safetensors contiguity bug

### DIFF
--- a/model2vec/distill/inference.py
+++ b/model2vec/distill/inference.py
@@ -235,7 +235,7 @@ def apply_pca(embeddings: np.ndarray, pca_dims: PCADimType) -> np.ndarray:
 
             orig_dims = embeddings.shape[1]
             p = PCA(n_components=pca_dims, svd_solver="full")
-            embeddings = p.fit_transform(embeddings)
+            embeddings = np.ascontiguousarray(p.fit_transform(embeddings))
 
             if embeddings.shape[1] < orig_dims:
                 explained_variance_ratio = np.sum(p.explained_variance_ratio_)

--- a/model2vec/persistence/persistence.py
+++ b/model2vec/persistence/persistence.py
@@ -46,11 +46,11 @@ def save_pretrained(
     folder_path = folder_path / subfolder if subfolder else folder_path
     folder_path.mkdir(exist_ok=True, parents=True)
 
-    model_weights = {"embeddings": embeddings}
+    model_weights = {"embeddings": np.ascontiguousarray(embeddings)}
     if weights is not None:
-        model_weights["weights"] = weights
+        model_weights["weights"] = np.ascontiguousarray(weights)
     if mapping is not None:
-        model_weights["mapping"] = mapping
+        model_weights["mapping"] = np.ascontiguousarray(mapping)
 
     save_file(model_weights, folder_path / "model.safetensors")
     tokenizer.save(str(folder_path / "tokenizer.json"), pretty=False)

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -251,6 +251,7 @@ def test_distill(
         )
         assert isinstance(static_model, StaticModel)
         assert static_model.embedding.shape == expected_shape
+        assert static_model.embedding.flags["C_CONTIGUOUS"]
         assert "mock-model" in static_model.config["tokenizer_name"]
         assert static_model.tokenizer is not None
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -79,6 +79,23 @@ def test_save_pretrained_non_contiguous_embeddings(tmp_path: Path, mock_tokenize
     np.testing.assert_array_equal(loaded_model.embedding, vectors)
 
 
+def test_save_pretrained_with_weights_and_mapping(tmp_path: Path, mock_tokenizer: Tokenizer) -> None:
+    """save_pretrained must persist weights and a token mapping when present."""
+    n_tokens = len(mock_tokenizer.get_vocab())
+    vectors = np.random.RandomState(0).randn(3, 4)
+    weights = np.random.RandomState(1).randn(n_tokens)
+    mapping = np.array([0, 1, 2, 0, 1][:n_tokens])
+
+    model = StaticModel(vectors=vectors, tokenizer=mock_tokenizer, weights=weights, token_mapping=mapping)
+    save_path = tmp_path / "saved_model"
+    model.save_pretrained(save_path)
+
+    loaded_model = StaticModel.from_pretrained(save_path)
+    np.testing.assert_array_equal(loaded_model.embedding, vectors)
+    np.testing.assert_array_equal(loaded_model.weights, weights)
+    np.testing.assert_array_equal(loaded_model.token_mapping, mapping)
+
+
 def test_maybe_get_cached_model_path() -> None:
     """Test cached model path."""
     model_id = "t/t"

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+import numpy as np
 import pytest
+from tokenizers import Tokenizer
 
 from model2vec.model import StaticModel
 from model2vec.persistence.hf import maybe_get_cached_model_path
@@ -62,6 +64,19 @@ def test_subfolder_loading(mock_static_model: StaticModel) -> None:
             StaticModel.from_pretrained(dir_name)
         model = StaticModel.from_pretrained(dir_name, subfolder="subfolder")
         assert isinstance(model, StaticModel)
+
+
+def test_save_pretrained_non_contiguous_embeddings(tmp_path: Path, mock_tokenizer: Tokenizer) -> None:
+    """Non-contiguous embeddings (e.g. Fortran-ordered) must round-trip exactly through safetensors."""
+    vectors = np.asfortranarray(np.random.RandomState(0).randn(len(mock_tokenizer.get_vocab()), 8))
+    assert not vectors.flags["C_CONTIGUOUS"]
+
+    model = StaticModel(vectors=vectors, tokenizer=mock_tokenizer)
+    save_path = tmp_path / "saved_model"
+    model.save_pretrained(save_path)
+
+    loaded_model = StaticModel.from_pretrained(save_path)
+    np.testing.assert_array_equal(loaded_model.embedding, vectors)
 
 
 def test_maybe_get_cached_model_path() -> None:


### PR DESCRIPTION
This PR introduces a guard against a safetensors bug or regression. Before, i.e. `safetensors < 0.8`, safetensors would happily roundtrip arrays that were in Fortran order. This is what sklearn's PCA with `solver == "full"` produces. Since 0.8, it will roundtrip arrays, but produce garbage. I'll report the issue in `safetensors` asap, but we now guard against it explicitly by casting in two different places, and through two unit tests.

Moving to a custom PCA implementation also solves this issue, which we'll also do. Nevertheless, I think it's still good to check the contiguity of arrays before we write them.