### PR TITLE
feat: disable progress bars, add hf hub as a direct dependency

### DIFF
--- a/model2vec/persistence/persistence.py
+++ b/model2vec/persistence/persistence.py
@@ -15,6 +15,7 @@ from model2vec.modelcards import create_model_card as make_model_card
 from model2vec.modelcards import get_metadata_from_readme
 from model2vec.persistence.datamodels import FOLDER_LAYOUTS, Layout
 from model2vec.persistence.hf import maybe_get_cached_model_path
+from model2vec.persistence.utils import SilentTqdm
 from model2vec.utils import SafeOpenProtocol
 
 logger = logging.getLogger(__name__)
@@ -142,8 +143,12 @@ def _resolve_folder(folder_or_repo_path: Path, token: str | None, force_download
         if folder := maybe_get_cached_model_path(str(folder_or_repo_path)):
             return folder
 
+    # We use `tqdm_class=SilentTqdm` to disable download progress bars.
+    # No partial because that doesn't always work, this is safer.
     folder = Path(
-        huggingface_hub.snapshot_download(str(folder_or_repo_path.as_posix()), repo_type="model", token=token)
+        huggingface_hub.snapshot_download(
+            str(folder_or_repo_path.as_posix()), repo_type="model", token=token, tqdm_class=SilentTqdm
+        )
     )
 
     return folder

--- a/model2vec/persistence/utils.py
+++ b/model2vec/persistence/utils.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from tqdm.auto import tqdm
+
+
+class SilentTqdm(tqdm):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Init a tqdm that's disabled by default."""
+        kwargs["disable"] = True
+        super().__init__(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "safetensors",
     "tokenizers>=0.20",
     "tqdm",
+    "huggingface-hub>=1.0.0",
 ]
 
 [build-system]

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -9,6 +9,7 @@ from tokenizers import Tokenizer
 
 from model2vec.model import StaticModel
 from model2vec.persistence.hf import maybe_get_cached_model_path
+from model2vec.persistence.utils import SilentTqdm
 
 
 def test_local_loading(mock_static_model: StaticModel) -> None:
@@ -94,6 +95,12 @@ def test_save_pretrained_with_weights_and_mapping(tmp_path: Path, mock_tokenizer
     np.testing.assert_array_equal(loaded_model.embedding, vectors)
     np.testing.assert_array_equal(loaded_model.weights, weights)
     np.testing.assert_array_equal(loaded_model.token_mapping, mapping)
+
+
+def test_silent_tqdm() -> None:
+    """Test that SilentTqdm is disabled by default."""
+    bar = SilentTqdm(range(3))
+    assert bar.disable is True
 
 
 def test_maybe_get_cached_model_path() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1228,6 +1228,7 @@ wheels = [
 name = "model2vec"
 source = { editable = "." }
 dependencies = [
+    { name = "huggingface-hub" },
     { name = "jinja2" },
     { name = "joblib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1278,6 +1279,7 @@ train = [
 
 [package.metadata]
 requires-dist = [
+    { name = "huggingface-hub", specifier = ">=1.0.0" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "jinja2" },
     { name = "joblib" },


### PR DESCRIPTION
This PR disables progress bars, which would show every time you loaded a static model. This was annoying.