### PR TITLE
fix(train): pad training batches with the model's pad id

### DIFF
--- a/model2vec/train/base.py
+++ b/model2vec/train/base.py
@@ -402,7 +402,7 @@ class BaseFinetuneable(nn.Module):
             encoded = self.tokenizer.encode_batch_fast(batch, add_special_tokens=False)
             tokenized.extend([encoding.ids[:max_length] for encoding in encoded])
 
-        return TextDataset(tokenized, y)
+        return TextDataset(tokenized, y, pad_id=self.pad_id)
 
     def _labels_to_tensor(self, labels: Any) -> torch.Tensor:
         """Turn the labels into a tensor."""

--- a/model2vec/train/dataset.py
+++ b/model2vec/train/dataset.py
@@ -4,17 +4,19 @@ from torch.utils.data import DataLoader, Dataset
 
 
 class TextDataset(Dataset):
-    def __init__(self, tokenized_texts: list[list[int]], targets: torch.Tensor) -> None:
+    def __init__(self, tokenized_texts: list[list[int]], targets: torch.Tensor, pad_id: int = 0) -> None:
         """A dataset of texts.
 
         :param tokenized_texts: The tokenized texts. Each text is a list of token ids.
         :param targets: The targets.
+        :param pad_id: The id used to pad batches. Must match the `pad_id` of the model being trained.
         :raises ValueError: If the number of targets does not match the number of texts.
         """
         if len(targets) != len(tokenized_texts):
             raise ValueError("Number of targets does not match number of texts.")
         self.tokenized_texts = tokenized_texts
         self.targets = targets
+        self.pad_id = pad_id
 
     def __len__(self) -> int:
         """Return the length of the dataset."""
@@ -24,13 +26,12 @@ class TextDataset(Dataset):
         """Gets an item."""
         return self.tokenized_texts[index], self.targets[index]
 
-    @staticmethod
-    def collate_fn(batch: list[tuple[list[list[int]], int]]) -> tuple[torch.Tensor, torch.Tensor]:
+    def collate_fn(self, batch: list[tuple[list[list[int]], int]]) -> tuple[torch.Tensor, torch.Tensor]:
         """Collate function."""
         texts, targets = zip(*batch)
 
         tensors: list[torch.Tensor] = [torch.LongTensor(x) for x in texts]
-        padded = pad_sequence(tensors, batch_first=True, padding_value=0)
+        padded = pad_sequence(tensors, batch_first=True, padding_value=self.pad_id)
 
         return padded, torch.stack(targets)
 

--- a/tests/test_trainable.py
+++ b/tests/test_trainable.py
@@ -147,6 +147,19 @@ def test_textdataset_init_incorrect() -> None:
         TextDataset([[0]], torch.arange(2))
 
 
+def test_training_batch_padding_is_masked(mock_vectors: np.ndarray, mock_tokenizer: Tokenizer) -> None:
+    """Training batches should pad with the model's pad id, so padding stays masked and out of the mean."""
+    s = StaticModelForClassification(vectors=torch.from_numpy(mock_vectors).float(), tokenizer=mock_tokenizer, pad_id=1)
+    texts = ["word2", "word2 word3"]
+
+    dataset = s._prepare_dataset(texts, torch.arange(2), max_length=None)
+    batch, _ = next(iter(dataset.to_dataloader(shuffle=False, batch_size=2)))
+
+    assert torch.equal(batch, s.tokenize(texts))
+    with torch.no_grad():
+        assert torch.allclose(s._encode(batch)[0], s._encode(s.tokenize(texts[:1]))[0])
+
+
 def test_predict(mock_trained_pipeline: StaticModelForClassification) -> None:
     """Test the predict function."""
     result = mock_trained_pipeline.predict(["dog cat", "dog"]).tolist()


### PR DESCRIPTION
`TextDataset.collate_fn` pads training batches with a hardcoded `padding_value=0`, but `_encode` masks padding by comparing against `self.pad_id`. When the tokenizer's pad token isn't id 0, every padded position holds a real vocabulary token that never gets masked — it gets a real embedding, a real `sigmoid(w[...])` weight, and it counts in the mean-pooling denominator. So a text's representation during training depends on which other texts landed in the same batch, and it doesn't match what `predict()` or the exported `StaticModel` produce for that same text.

The inference path in the same class already does it right (`tokenize` uses `padding_value=self.pad_id`), as does `distill/inference.py` — the training collate was the only place left on 0.

It stays latent on the official `potion-*` models because their pad resolves to 0, but anything distilled from a RoBERTa/XLM-R base hits it: `paraphrase-multilingual-MiniLM-L12-v2` and `multilingual-e5-small` both resolve to `pad_id=1` via `get_probable_pad_token_id`.

`TextDataset` now takes the pad id (defaulting to 0, so the existing constructor calls still work) and `_prepare_dataset` passes the model's. `collate_fn` had to stop being a staticmethod; it's only ever reached through `to_dataloader`, which already binds it off the instance.

The test builds a model with `pad_id=1` and checks the training batch matches what `tokenize` produces, plus that a text encodes the same whether or not it got padded. Without the fix it sees `[[2, 0], [2, 3]]` against `[[2, 1], [2, 3]]`. Suite is 286 passed, ruff and mypy clean.
